### PR TITLE
Finalize `crate::asm::signature` and `crate::asm::node::signature` modules

### DIFF
--- a/src/asm/node/signature.rs
+++ b/src/asm/node/signature.rs
@@ -215,6 +215,7 @@ impl FormalTypeParameterVisitable for MethodSignatureCollector {
     }
 }
 
+/// Data representation of formal type parameter in signatures.
 #[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct FormalTypeParameter {
     parameter_name: String,

--- a/src/asm/node/signature.rs
+++ b/src/asm/node/signature.rs
@@ -23,9 +23,7 @@ pub enum Signature {
         interfaces: Vec<Type>,
     },
     /// Data representation of field signature.
-    Field {
-        field_type: Type,
-    },
+    Field { field_type: Type },
     /// Data representation of method signature.
     Method {
         formal_type_parameters: Vec<FormalTypeParameter>,

--- a/src/asm/node/signature.rs
+++ b/src/asm/node/signature.rs
@@ -3,7 +3,13 @@ use std::collections::VecDeque;
 use serde::{Deserialize, Serialize};
 
 use crate::asm::class::ClassReaderImpl;
-use crate::asm::signature::{accept_class_signature_visitor, accept_field_signature_visitor, accept_method_signature_visitor, ClassSignatureVisitor, ClassSignatureWriter, FieldSignatureVisitor, FieldSignatureWriter, FormalTypeParameterVisitable, FormalTypeParameterVisitor, MethodSignatureVisitor, MethodSignatureWriter, SignatureVisitorImpl, TypeVisitor, Wildcard};
+use crate::asm::signature::{
+    accept_class_signature_visitor, accept_field_signature_visitor,
+    accept_method_signature_visitor, ClassSignatureVisitor, ClassSignatureWriter,
+    FieldSignatureVisitor, FieldSignatureWriter, FormalTypeParameterVisitable,
+    FormalTypeParameterVisitor, MethodSignatureVisitor, MethodSignatureWriter,
+    SignatureVisitorImpl, TypeVisitor, Wildcard,
+};
 use crate::error::{KapiError, KapiResult};
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -31,7 +37,7 @@ impl Signature {
     {
         let string = string.into();
         let mut collector = ClassSignatureCollector::default();
-        
+
         accept_class_signature_visitor(&string, &mut collector)?;
 
         collector
@@ -48,7 +54,7 @@ impl Signature {
     {
         let string = string.into();
         let mut collector = FieldSignatureCollector::default();
-        
+
         accept_field_signature_visitor(&string, &mut collector)?;
 
         collector
@@ -65,7 +71,7 @@ impl Signature {
     {
         let string = string.into();
         let mut collector = MethodSignatureCollector::default();
-        
+
         accept_method_signature_visitor(&string, &mut collector)?;
 
         collector

--- a/src/asm/node/signature.rs
+++ b/src/asm/node/signature.rs
@@ -282,7 +282,7 @@ const SUPER: char = '-';
 const INSTANCEOF: char = '=';
 
 /// An enum representation for wildcard indicators, which is used in
-/// [`Type::WildcardTypeArgument`](crate::asm::node::signature::Type::WildcardTypeArgument) as class
+/// [`Type::WildcardTypeArgument`] as class
 /// type argument bound.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(u8)]
@@ -321,15 +321,7 @@ impl TryFrom<&char> for Wildcard {
     type Error = KapiError;
 
     fn try_from(value: &char) -> KapiResult<Self> {
-        match *value {
-            EXTENDS => Ok(Wildcard::EXTENDS),
-            SUPER => Ok(Wildcard::SUPER),
-            INSTANCEOF => Ok(Self::INSTANCEOF),
-            _ => Err(KapiError::ArgError(format!(
-                "Character {} cannot be converted into Wildcard",
-                value
-            ))),
-        }
+        TryFrom::<char>::try_from(*value)
     }
 }
 
@@ -344,6 +336,12 @@ pub enum BaseType {
     Float = 'F' as u8,
     Double = 'D' as u8,
     Void = 'V' as u8,
+}
+
+impl Into<char> for BaseType {
+    fn into(self) -> char {
+        self as u8 as char
+    }
 }
 
 impl TryFrom<char> for BaseType {
@@ -364,6 +362,14 @@ impl TryFrom<char> for BaseType {
                 value
             ))),
         }
+    }
+}
+
+impl TryFrom<&char> for BaseType {
+    type Error = KapiError;
+
+    fn try_from(value: &char) -> KapiResult<Self> {
+        TryFrom::<char>::try_from(*value)
     }
 }
 
@@ -403,9 +409,8 @@ impl<F> TypeVisitor for TypeCollector<F>
 where
     F: FnMut(Type),
 {
-    fn visit_base_type(&mut self, char: &char) {
-        self.holder = TryInto::<BaseType>::try_into(*char)
-            .map_or(Type::Unknown, |base_type| Type::BaseType(base_type));
+    fn visit_base_type(&mut self, base_type: BaseType) {
+        self.holder = Type::BaseType(base_type);
     }
 
     fn visit_array_type(&mut self) {

--- a/src/asm/node/signature.rs
+++ b/src/asm/node/signature.rs
@@ -3,12 +3,7 @@ use std::collections::VecDeque;
 use serde::{Deserialize, Serialize};
 
 use crate::asm::class::ClassReaderImpl;
-use crate::asm::signature::{
-    ClassSignatureReader, ClassSignatureVisitor, ClassSignatureWriter, FieldSignatureReader,
-    FieldSignatureVisitor, FieldSignatureWriter, FormalTypeParameterVisitable,
-    FormalTypeParameterVisitor, MethodSignatureReader, MethodSignatureVisitor,
-    MethodSignatureWriter, SignatureVisitorImpl, TypeVisitor, Wildcard,
-};
+use crate::asm::signature::{accept_class_signature_visitor, accept_field_signature_visitor, accept_method_signature_visitor, ClassSignatureVisitor, ClassSignatureWriter, FieldSignatureVisitor, FieldSignatureWriter, FormalTypeParameterVisitable, FormalTypeParameterVisitor, MethodSignatureVisitor, MethodSignatureWriter, SignatureVisitorImpl, TypeVisitor, Wildcard};
 use crate::error::{KapiError, KapiResult};
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -36,9 +31,8 @@ impl Signature {
     {
         let string = string.into();
         let mut collector = ClassSignatureCollector::default();
-        let mut reader = ClassSignatureReader::new(&string);
-
-        reader.accept(&mut collector)?;
+        
+        accept_class_signature_visitor(&string, &mut collector)?;
 
         collector
             .signature
@@ -54,9 +48,8 @@ impl Signature {
     {
         let string = string.into();
         let mut collector = FieldSignatureCollector::default();
-        let mut reader = FieldSignatureReader::new(&string);
-
-        reader.accept(&mut collector)?;
+        
+        accept_field_signature_visitor(&string, &mut collector)?;
 
         collector
             .signature
@@ -72,9 +65,8 @@ impl Signature {
     {
         let string = string.into();
         let mut collector = MethodSignatureCollector::default();
-        let mut reader = MethodSignatureReader::new(&string);
-
-        reader.accept(&mut collector)?;
+        
+        accept_method_signature_visitor(&string, &mut collector)?;
 
         collector
             .signature

--- a/src/asm/node/signature.rs
+++ b/src/asm/node/signature.rs
@@ -268,6 +268,7 @@ where
     }
 }
 
+/// Data representation of Type in signatures.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Type {
     BaseType(BaseType),
@@ -277,6 +278,8 @@ pub enum Type {
     TypeVariable(String),
     TypeArgument,
     WildcardTypeArgument(Wildcard, Box<Type>),
+    /// Unknown is only used in internal code for placeholder usage, you should not see it appears
+    /// in returned data structure.
     Unknown,
 }
 

--- a/src/asm/node/signature.rs
+++ b/src/asm/node/signature.rs
@@ -337,6 +337,7 @@ impl TryFrom<&char> for Wildcard {
     }
 }
 
+/// Data representation of base type in descriptor.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum BaseType {

--- a/src/asm/node/signature.rs
+++ b/src/asm/node/signature.rs
@@ -12,16 +12,21 @@ use crate::asm::signature::{
 };
 use crate::error::{KapiError, KapiResult};
 
+/// Data representation of signatures, including [`Class`](Signature::Class), [`Field`](Signature::Field),
+/// and [`Method`](Signature::Method).
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Signature {
+    /// Data representation of class signature.
     Class {
         formal_type_parameters: Vec<FormalTypeParameter>,
         super_class: Type,
         interfaces: Vec<Type>,
     },
+    /// Data representation of field signature.
     Field {
         field_type: Type,
     },
+    /// Data representation of method signature.
     Method {
         formal_type_parameters: Vec<FormalTypeParameter>,
         parameter_types: Vec<Type>,
@@ -31,6 +36,7 @@ pub enum Signature {
 }
 
 impl Signature {
+    /// Converts signature string into [`Signature::Class`](Signature::Class).
     pub fn class_signature_from_str<S>(string: S) -> KapiResult<Self>
     where
         S: Into<String>,
@@ -48,6 +54,7 @@ impl Signature {
             )))
     }
 
+    /// Converts signature string into [`Signature::Field`](Signature::Field).
     pub fn field_signature_from_str<S>(string: S) -> KapiResult<Self>
     where
         S: Into<String>,
@@ -65,6 +72,7 @@ impl Signature {
             )))
     }
 
+    /// Converts signature string into [`Signature::Method`](Signature::Method).
     pub fn method_signature_from_str<S>(string: S) -> KapiResult<Self>
     where
         S: Into<String>,

--- a/src/asm/node/signature.rs
+++ b/src/asm/node/signature.rs
@@ -1,8 +1,14 @@
 use std::collections::VecDeque;
+
 use serde::{Deserialize, Serialize};
 
 use crate::asm::class::ClassReaderImpl;
-use crate::asm::signature::{ClassSignatureReader, ClassSignatureVisitor, ClassSignatureWriter, FieldSignatureReader, FieldSignatureVisitor, FieldSignatureWriter, FormalTypeParameterVisitable, FormalTypeParameterVisitor, MethodSignatureReader, MethodSignatureVisitor, MethodSignatureWriter, SignatureVisitorImpl, TypeVisitor, Wildcard};
+use crate::asm::signature::{
+    ClassSignatureReader, ClassSignatureVisitor, ClassSignatureWriter, FieldSignatureReader,
+    FieldSignatureVisitor, FieldSignatureWriter, FormalTypeParameterVisitable,
+    FormalTypeParameterVisitor, MethodSignatureReader, MethodSignatureVisitor,
+    MethodSignatureWriter, SignatureVisitorImpl, TypeVisitor, Wildcard,
+};
 use crate::error::{KapiError, KapiResult};
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -49,9 +55,9 @@ impl Signature {
         let string = string.into();
         let mut collector = FieldSignatureCollector::default();
         let mut reader = FieldSignatureReader::new(&string);
-        
+
         reader.accept(&mut collector)?;
-        
+
         collector
             .signature
             .ok_or(KapiError::ClassParseError(format!(
@@ -61,8 +67,8 @@ impl Signature {
     }
 
     pub fn method_signature_from_str<S>(string: S) -> KapiResult<Self>
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         let string = string.into();
         let mut collector = MethodSignatureCollector::default();
@@ -374,7 +380,7 @@ where
 
     fn visit_end(&mut self) {
         let mut typ = self.holder.clone();
-        
+
         while let Some(wildcard) = self.stack_actions.pop_back() {
             if let Some(wildcard) = wildcard {
                 typ = Self::wrap_type_argument(wildcard.clone(), typ);
@@ -420,9 +426,9 @@ mod test {
     #[case("<T:Ljava/lang/Object;>(Z[[ZTT;)Ljava/lang/Object;^Ljava/lang/Exception;")]
     fn test_method_signatures(#[case] signature: &'static str) -> KapiResult<()> {
         let method_signature = Signature::method_signature_from_str(signature)?;
-        
+
         assert_yaml_snapshot!(method_signature);
-        
+
         Ok(())
     }
 }

--- a/src/asm/node/signature.rs
+++ b/src/asm/node/signature.rs
@@ -8,7 +8,7 @@ use crate::asm::signature::{
     accept_method_signature_visitor, ClassSignatureVisitor, ClassSignatureWriter,
     FieldSignatureVisitor, FieldSignatureWriter, FormalTypeParameterVisitable,
     FormalTypeParameterVisitor, MethodSignatureVisitor, MethodSignatureWriter,
-    SignatureVisitorImpl, TypeVisitor, Wildcard,
+    SignatureVisitorImpl, TypeVisitor,
 };
 use crate::error::{KapiError, KapiResult};
 
@@ -274,6 +274,62 @@ pub enum Type {
 impl Default for Type {
     fn default() -> Self {
         Self::Unknown
+    }
+}
+
+const EXTENDS: char = '+';
+const SUPER: char = '-';
+const INSTANCEOF: char = '=';
+
+/// An enum representation for wildcard indicators, which is used in
+/// [`Type::WildcardTypeArgument`](crate::asm::node::signature::Type::WildcardTypeArgument) as class
+/// type argument bound.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum Wildcard {
+    /// Indicates type argument must extends class bound, see java's upper bounds wildcard.
+    EXTENDS = EXTENDS as u8,
+    /// Indicates type argument must super class bound, see java's lower bounds wildcard.
+    SUPER = SUPER as u8,
+    /// Indicates type argument must be instance of specified type.
+    INSTANCEOF = INSTANCEOF as u8,
+}
+
+impl Into<char> for Wildcard {
+    fn into(self) -> char {
+        self as u8 as char
+    }
+}
+
+impl TryFrom<char> for Wildcard {
+    type Error = KapiError;
+
+    fn try_from(value: char) -> KapiResult<Self> {
+        match value {
+            EXTENDS => Ok(Wildcard::EXTENDS),
+            SUPER => Ok(Wildcard::SUPER),
+            INSTANCEOF => Ok(Self::INSTANCEOF),
+            _ => Err(KapiError::ArgError(format!(
+                "Character {} cannot be converted into Wildcard",
+                value
+            ))),
+        }
+    }
+}
+
+impl TryFrom<&char> for Wildcard {
+    type Error = KapiError;
+
+    fn try_from(value: &char) -> KapiResult<Self> {
+        match *value {
+            EXTENDS => Ok(Wildcard::EXTENDS),
+            SUPER => Ok(Wildcard::SUPER),
+            INSTANCEOF => Ok(Self::INSTANCEOF),
+            _ => Err(KapiError::ArgError(format!(
+                "Character {} cannot be converted into Wildcard",
+                value
+            ))),
+        }
     }
 }
 

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -149,14 +149,25 @@ pub trait FormalTypeParameterVisitable {
     }
 }
 
+/// A visitor to visit formal type parameters in generic signature. 
+///
+/// # Implemented Examples
+///
+/// See [FormalTypeParameterWriter]for more info.
 #[allow(unused_variables)]
 pub trait FormalTypeParameterVisitor {
+    /// Visits class bound in formal type parameter. This would be only called up to once per parameter.
     fn visit_class_bound(&mut self) -> Box<dyn TypeVisitor + '_> {
         Box::new(SignatureVisitorImpl::default())
     }
+    
+    /// Visits interface bound in formal type parameter. This could be called by multiple times when
+    /// there's more than 1 interface bounds declared.
     fn visit_interface_bound(&mut self) -> Box<dyn TypeVisitor + '_> {
         Box::new(SignatureVisitorImpl::default())
     }
+    
+    /// Finalizes the visitor for further process.
     fn visit_end(&mut self) {}
 }
 

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -13,7 +13,7 @@ const EXTENDS: char = '+';
 const SUPER: char = '-';
 const INSTANCEOF: char = '=';
 
-/// An enum representation for wildcard indicators, which is used in 
+/// An enum representation for wildcard indicators, which is used in
 /// [`Type::WildcardTypeArgument`](crate::asm::node::signature::Type::WildcardTypeArgument) as class
 /// type argument bound.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -65,13 +65,22 @@ impl TryFrom<&char> for Wildcard {
     }
 }
 
+/// A visitor to visit class generic signature. This trait requires struct also implements 
+/// [FormalTypeParameterVisitable].
 pub trait ClassSignatureVisitor: FormalTypeParameterVisitable {
+    /// Visits class generic signature's super class type. This would be called on every classes 
+    /// expect `java.lang.Object`.
     fn visit_super_class(&mut self) -> Box<dyn TypeVisitor + '_> {
         Box::new(SignatureVisitorImpl::default())
     }
+
+    /// Visits class generic signature's interface type. This could be called by multiple times
+    /// when there's more than 1 interfaces implemented.
     fn visit_interface(&mut self) -> Box<dyn TypeVisitor + '_> {
         Box::new(SignatureVisitorImpl::default())
     }
+
+    /// Finalizes the visitor for further process.
     fn visit_end(&mut self) {}
 }
 

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -104,8 +104,12 @@ pub trait MethodSignatureVisitor: FormalTypeParameterVisitable {
     fn visit_end(&mut self) {}
 }
 
+/// A trait indicates super-trait visitor has formal type parameter section to be visited, which are
+/// [ClassSignatureVisitor] and [MethodSignatureVisitor].
 #[allow(unused_variables)]
 pub trait FormalTypeParameterVisitable {
+    /// Visits generic signature's formal type parameter. This could be called by multiple times
+    /// when there's more than 1 formal type parameter declared.
     fn visit_formal_type_parameter(
         &mut self,
         name: &String,

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -522,6 +522,9 @@ where
     }
 }
 
+/// A default implementation of class signature writer.
+/// 
+/// This is commonly used in class file generation.
 #[derive(Debug, Default)]
 pub struct ClassSignatureWriter {
     signature_builder: String,
@@ -529,7 +532,10 @@ pub struct ClassSignatureWriter {
 }
 
 impl ClassSignatureWriter {
-    fn with_capacity(size: usize) -> Self {
+    /// Reserve capacity for builder to build.
+    /// 
+    /// This is useful when mass appending is required.
+    pub fn with_capacity(size: usize) -> Self {
         Self {
             signature_builder: String::with_capacity(size),
             has_formal: false,
@@ -579,13 +585,19 @@ impl FormalTypeParameterVisitable for ClassSignatureWriter {
     }
 }
 
+/// A default implementation of field signature writer.
+///
+/// This is commonly used in class file generation.
 #[derive(Debug, Default)]
 pub struct FieldSignatureWriter {
     signature_builder: String,
 }
 
 impl FieldSignatureWriter {
-    fn with_capacity(size: usize) -> Self {
+    /// Reserve capacity for builder to build.
+    ///
+    /// This is useful when mass appending is required.
+    pub fn with_capacity(size: usize) -> Self {
         Self {
             signature_builder: String::with_capacity(size),
         }
@@ -611,8 +623,14 @@ pub struct MethodSignatureWriter {
     has_parameters: bool,
 }
 
+/// A default implementation of method signature writer.
+///
+/// This is commonly used in class file generation.
 impl MethodSignatureWriter {
-    fn with_capacity(size: usize) -> Self {
+    /// Reserve capacity for builder to build.
+    ///
+    /// This is useful when mass appending is required.
+    pub fn with_capacity(size: usize) -> Self {
         Self {
             signature_builder: String::with_capacity(size),
             has_formal: false,

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -178,36 +178,36 @@ pub trait FormalTypeParameterVisitor {
 /// See [TypeWriter] for more info.
 #[allow(unused_variables)]
 pub trait TypeVisitor {
-    /// Visits base type in signature. This could be any type defined by 
+    /// Visits base type in signature. This could be any type defined by
     /// [`BaseType`](crate::asm::node::signature::BaseType).
     fn visit_base_type(&mut self, char: &char) {}
-    
-    /// Visits array type in signature. Further type visiting is required after 
-    /// [`visit_array_type`](TypeVisitor::visit_array_type) called. For example: you can call this 
-    /// [`visit_array_type`](TypeVisitor::visit_array_type) then call 
+
+    /// Visits array type in signature. Further type visiting is required after
+    /// [`visit_array_type`](TypeVisitor::visit_array_type) called. For example: you can call this
+    /// [`visit_array_type`](TypeVisitor::visit_array_type) then call
     /// [`visit_base_type`](TypeVisitor::visit_base_type) to construct a base type array.
     fn visit_array_type(&mut self) {}
-    
+
     /// Visits class type in signature.
     fn visit_class_type(&mut self, name: &String) {}
-    
+
     /// Visits inner class type in signature. Required calling [`visit_class_type`](TypeVisitor::visit_class_type)
     /// before calling [`visit_inner_class_type`](TypeVisitor::visit_inner_class_type).
     fn visit_inner_class_type(&mut self, name: &String) {}
-    
+
     /// Visits type variable in signature.
     fn visit_type_variable(&mut self, name: &String) {}
-    
+
     /// Visits type argument in signature. Required calling [visit_class_type](TypeVisitor::visit_class_type)
     /// before calling [`visit_type_argument`](TypeVisitor::visit_type_argument).
-    /// 
+    ///
     /// This function will be called when the following type is unbounded. For type argument with
-    /// wildcard, see [`visit_type_argument_wildcard`](TypeVisitor::visit_type_argument_wildcard) for 
+    /// wildcard, see [`visit_type_argument_wildcard`](TypeVisitor::visit_type_argument_wildcard) for
     /// more info.
     fn visit_type_argument(&mut self) {}
-    
-    /// Visits type type argument with wildcard indicator in signature. Required calling 
-    /// [`visit_class_type`](TypeVisitor::visit_class_type) before calling 
+
+    /// Visits type type argument with wildcard indicator in signature. Required calling
+    /// [`visit_class_type`](TypeVisitor::visit_class_type) before calling
     /// [`visit_type_argument`](TypeVisitor::visit_type_argument).
     fn visit_type_argument_wildcard(&mut self, wildcard: Wildcard) {}
 

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::asm::field::FieldVisitor;
-use crate::asm::node::signature::Wildcard;
+use crate::asm::node::signature::{BaseType, Wildcard};
 use crate::error::{KapiError, KapiResult};
 
 /// A visitor to visit class generic signature. This trait requires struct also implements
@@ -124,8 +124,8 @@ pub trait FormalTypeParameterVisitor {
 #[allow(unused_variables)]
 pub trait TypeVisitor {
     /// Visits base type in signature. This could be any type defined by
-    /// [`BaseType`](crate::asm::node::signature::BaseType).
-    fn visit_base_type(&mut self, char: &char) {}
+    /// [`BaseType`].
+    fn visit_base_type(&mut self, base_type: BaseType) {}
 
     /// Visits array type in signature. Further type visiting is required after
     /// [`visit_array_type`](TypeVisitor::visit_array_type) called. For example: you can call this
@@ -331,7 +331,7 @@ where
 
     match char {
         'Z' | 'C' | 'B' | 'S' | 'I' | 'F' | 'J' | 'D' | 'V' => {
-            visitor.visit_base_type(&char);
+            visitor.visit_base_type(TryFrom::try_from(char)?);
             visitor.visit_end();
             signature_iter.next();
             Ok(())
@@ -468,7 +468,7 @@ where
 }
 
 /// A default implementation of class signature writer.
-/// 
+///
 /// This is commonly used in class file generation.
 #[derive(Debug, Default)]
 pub struct ClassSignatureWriter {
@@ -478,7 +478,7 @@ pub struct ClassSignatureWriter {
 
 impl ClassSignatureWriter {
     /// Reserve capacity for builder to build.
-    /// 
+    ///
     /// This is useful when mass appending is required.
     pub fn with_capacity(size: usize) -> Self {
         Self {
@@ -693,8 +693,8 @@ impl<'parent> TypeWriter<'parent> {
 }
 
 impl<'parent> TypeVisitor for TypeWriter<'parent> {
-    fn visit_base_type(&mut self, char: &char) {
-        self.parent_builder.push(*char);
+    fn visit_base_type(&mut self, base_type: BaseType) {
+        self.parent_builder.push(base_type.into());
     }
 
     fn visit_array_type(&mut self) {

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -231,7 +231,8 @@ pub fn accept_class_signature_visitor(
     signature: impl Into<String>,
     visitor: &mut impl ClassSignatureVisitor,
 ) -> KapiResult<()> {
-    let mut signature_iter = signature.into().chars().peekable();
+    let signature = signature.into();
+    let mut signature_iter = signature.chars().peekable();
 
     // Formal type parameters
     accept_formal_type_parameters(&mut signature_iter, visitor)?;
@@ -254,7 +255,8 @@ pub fn accept_field_signature_visitor(
     signature: impl Into<String>,
     visitor: &mut impl FieldSignatureVisitor,
 ) -> KapiResult<()> {
-    let mut signature_iter = signature.into().chars().peekable();
+    let signature = signature.into();
+    let mut signature_iter = signature.chars().peekable();
 
     // Field type
     accept_type(&mut signature_iter, &mut visitor.visit_field_type())?;
@@ -269,7 +271,8 @@ pub fn accept_method_signature_visitor(
     signature: impl Into<String>,
     visitor: &mut impl MethodSignatureVisitor,
 ) -> KapiResult<()> {
-    let mut signature_iter = signature.into().chars().peekable();
+    let signature = signature.into();
+    let mut signature_iter = signature.chars().peekable();
 
     // Formal type parameters
     accept_formal_type_parameters(&mut signature_iter, visitor)?;

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -13,11 +13,17 @@ const EXTENDS: char = '+';
 const SUPER: char = '-';
 const INSTANCEOF: char = '=';
 
+/// An enum representation for wildcard indicators, which is used in 
+/// [`Type::WildcardTypeArgument`](crate::asm::node::signature::Type::WildcardTypeArgument) as class
+/// type argument bound.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum Wildcard {
+    /// Indicates type argument must extends class bound, see java's upper bounds wildcard.
     EXTENDS = EXTENDS as u8,
+    /// Indicates type argument must super class bound, see java's lower bounds wildcard.
     SUPER = SUPER as u8,
+    /// Indicates type argument must be instance of specified type.
     INSTANCEOF = INSTANCEOF as u8,
 }
 

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -227,6 +227,7 @@ impl FormalTypeParameterVisitable for SignatureVisitorImpl {}
 impl FormalTypeParameterVisitor for SignatureVisitorImpl {}
 impl TypeVisitor for SignatureVisitorImpl {}
 
+/// Accepts a [`ClassSignatureVisitor`] and visits given signature.
 pub fn accept_class_signature_visitor<S>(
     signature: S,
     visitor: &mut impl ClassSignatureVisitor,
@@ -254,6 +255,7 @@ where
     strict_check_iter_empty(&mut signature_iter)
 }
 
+/// Accepts a [`FieldSignatureVisitor`] and visits given signature.
 pub fn accept_field_signature_visitor<S>(
     signature: S,
     visitor: &mut impl FieldSignatureVisitor,
@@ -273,6 +275,7 @@ where
     strict_check_iter_empty(&mut signature_iter)
 }
 
+/// Accepts a [`MethodSignatureVisitor`] and visits given signature.
 pub fn accept_method_signature_visitor<S>(
     signature: S,
     visitor: &mut impl MethodSignatureVisitor,

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -67,6 +67,10 @@ impl TryFrom<&char> for Wildcard {
 
 /// A visitor to visit class generic signature. This trait requires struct also implements 
 /// [FormalTypeParameterVisitable].
+/// 
+/// # Implemented Examples
+/// 
+/// See [ClassSignatureWriter] for more info.
 pub trait ClassSignatureVisitor: FormalTypeParameterVisitable {
     /// Visits class generic signature's super class type. This would be called on every classes 
     /// expect `java.lang.Object`.
@@ -84,10 +88,18 @@ pub trait ClassSignatureVisitor: FormalTypeParameterVisitable {
     fn visit_end(&mut self) {}
 }
 
+/// A visitor to visit field generic signature.
+///
+/// # Implemented Examples
+///
+/// See [FieldSignatureWriter] for more info.
 pub trait FieldSignatureVisitor {
+    /// Visits field generic signature's type.
     fn visit_field_type(&mut self) -> Box<dyn TypeVisitor + '_> {
         Box::new(SignatureVisitorImpl::default())
     }
+
+    /// Finalizes the visitor for further process.
     fn visit_end(&mut self) {}
 }
 
@@ -106,6 +118,10 @@ pub trait MethodSignatureVisitor: FormalTypeParameterVisitable {
 
 /// A trait indicates super-trait visitor has formal type parameter section to be visited, which are
 /// [ClassSignatureVisitor] and [MethodSignatureVisitor].
+///
+/// # Implemented Examples
+///
+/// See [ClassSignatureWriter] and [MethodSignatureWriter] for more info.
 #[allow(unused_variables)]
 pub trait FormalTypeParameterVisitable {
     /// Visits generic signature's formal type parameter. This could be called by multiple times

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -215,6 +215,8 @@ pub trait TypeVisitor {
     fn visit_end(&mut self) {}
 }
 
+/// Default signature visitor for internal usage only. This visitor does not have any effect on visiting
+/// signatures.
 #[derive(Debug, Default)]
 pub struct SignatureVisitorImpl {}
 

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -1,5 +1,5 @@
-use std::{default, iter::Peekable, str::CharIndices};
 use std::collections::VecDeque;
+use std::{default, iter::Peekable, str::CharIndices};
 
 use either::Either;
 use itertools::Itertools;
@@ -227,10 +227,13 @@ impl FormalTypeParameterVisitable for SignatureVisitorImpl {}
 impl FormalTypeParameterVisitor for SignatureVisitorImpl {}
 impl TypeVisitor for SignatureVisitorImpl {}
 
-pub fn accept_class_signature_visitor(
-    signature: impl Into<String>,
+pub fn accept_class_signature_visitor<S>(
+    signature: S,
     visitor: &mut impl ClassSignatureVisitor,
-) -> KapiResult<()> {
+) -> KapiResult<()>
+where
+    S: Into<String>,
+{
     let signature = signature.into();
     let mut signature_iter = signature.chars().peekable();
 
@@ -251,10 +254,13 @@ pub fn accept_class_signature_visitor(
     strict_check_iter_empty(&mut signature_iter)
 }
 
-pub fn accept_field_signature_visitor(
-    signature: impl Into<String>,
+pub fn accept_field_signature_visitor<S>(
+    signature: S,
     visitor: &mut impl FieldSignatureVisitor,
-) -> KapiResult<()> {
+) -> KapiResult<()>
+where
+    S: Into<String>,
+{
     let signature = signature.into();
     let mut signature_iter = signature.chars().peekable();
 
@@ -267,10 +273,13 @@ pub fn accept_field_signature_visitor(
     strict_check_iter_empty(&mut signature_iter)
 }
 
-pub fn accept_method_signature_visitor(
-    signature: impl Into<String>,
+pub fn accept_method_signature_visitor<S>(
+    signature: S,
     visitor: &mut impl MethodSignatureVisitor,
-) -> KapiResult<()> {
+) -> KapiResult<()>
+where
+    S: Into<String>,
+{
     let signature = signature.into();
     let mut signature_iter = signature.chars().peekable();
 

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -103,16 +103,31 @@ pub trait FieldSignatureVisitor {
     fn visit_end(&mut self) {}
 }
 
+/// A visitor to visit method generic signature. This trait requires struct also implements 
+/// [FormalTypeParameterVisitable].
+///
+/// # Implemented Examples
+///
+/// See [MethodSignatureWriter] for more info.
 pub trait MethodSignatureVisitor: FormalTypeParameterVisitable {
+    /// Visits method generic signature's parameter type. This could be called by multiple times
+    /// when there's more than 1 parameters declared.
     fn visit_parameter_type(&mut self) -> Box<dyn TypeVisitor + '_> {
         Box::new(SignatureVisitorImpl::default())
     }
+
+    /// Visits method generic signature's return type. This would be only called once per method.
     fn visit_return_type(&mut self) -> Box<dyn TypeVisitor + '_> {
         Box::new(SignatureVisitorImpl::default())
     }
+    
+    /// Visits method generic signature's exception type. This could be called by multiple times
+    /// when there's more than 1 exception types declared.
     fn visit_exception_type(&mut self) -> Box<dyn TypeVisitor + '_> {
         Box::new(SignatureVisitorImpl::default())
     }
+
+    /// Finalizes the visitor for further process.
     fn visit_end(&mut self) {}
 }
 

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -250,7 +250,7 @@ pub fn accept_class_signature_visitor(
     strict_check_iter_empty(&mut signature_iter)
 }
 
-fn accept_field_signature_visitor(
+pub fn accept_field_signature_visitor(
     signature: impl Into<String>,
     visitor: &mut impl FieldSignatureVisitor,
 ) -> KapiResult<()> {
@@ -265,7 +265,7 @@ fn accept_field_signature_visitor(
     strict_check_iter_empty(&mut signature_iter)
 }
 
-fn accept_method_signature_visitor(
+pub fn accept_method_signature_visitor(
     signature: impl Into<String>,
     visitor: &mut impl MethodSignatureVisitor,
 ) -> KapiResult<()> {

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -7,63 +7,8 @@ use serde::{Deserialize, Serialize};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::asm::field::FieldVisitor;
+use crate::asm::node::signature::Wildcard;
 use crate::error::{KapiError, KapiResult};
-
-const EXTENDS: char = '+';
-const SUPER: char = '-';
-const INSTANCEOF: char = '=';
-
-/// An enum representation for wildcard indicators, which is used in
-/// [`Type::WildcardTypeArgument`](crate::asm::node::signature::Type::WildcardTypeArgument) as class
-/// type argument bound.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[repr(u8)]
-pub enum Wildcard {
-    /// Indicates type argument must extends class bound, see java's upper bounds wildcard.
-    EXTENDS = EXTENDS as u8,
-    /// Indicates type argument must super class bound, see java's lower bounds wildcard.
-    SUPER = SUPER as u8,
-    /// Indicates type argument must be instance of specified type.
-    INSTANCEOF = INSTANCEOF as u8,
-}
-
-impl Into<char> for Wildcard {
-    fn into(self) -> char {
-        self as u8 as char
-    }
-}
-
-impl TryFrom<char> for Wildcard {
-    type Error = KapiError;
-
-    fn try_from(value: char) -> KapiResult<Self> {
-        match value {
-            EXTENDS => Ok(Wildcard::EXTENDS),
-            SUPER => Ok(Wildcard::SUPER),
-            INSTANCEOF => Ok(Self::INSTANCEOF),
-            _ => Err(KapiError::ArgError(format!(
-                "Character {} cannot be converted into Wildcard",
-                value
-            ))),
-        }
-    }
-}
-
-impl TryFrom<&char> for Wildcard {
-    type Error = KapiError;
-
-    fn try_from(value: &char) -> KapiResult<Self> {
-        match *value {
-            EXTENDS => Ok(Wildcard::EXTENDS),
-            SUPER => Ok(Wildcard::SUPER),
-            INSTANCEOF => Ok(Self::INSTANCEOF),
-            _ => Err(KapiError::ArgError(format!(
-                "Character {} cannot be converted into Wildcard",
-                value
-            ))),
-        }
-    }
-}
 
 /// A visitor to visit class generic signature. This trait requires struct also implements
 /// [FormalTypeParameterVisitable].

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -153,7 +153,7 @@ pub trait FormalTypeParameterVisitable {
 ///
 /// # Implemented Examples
 ///
-/// See [FormalTypeParameterWriter]for more info.
+/// See [FormalTypeParameterWriter] for more info.
 #[allow(unused_variables)]
 pub trait FormalTypeParameterVisitor {
     /// Visits class bound in formal type parameter. This would be only called up to once per parameter.
@@ -171,15 +171,47 @@ pub trait FormalTypeParameterVisitor {
     fn visit_end(&mut self) {}
 }
 
+/// A visitor to visit types in generic signature.
+///
+/// # Implemented Examples
+///
+/// See [TypeWriter] for more info.
 #[allow(unused_variables)]
 pub trait TypeVisitor {
+    /// Visits base type in signature. This could be any type defined by 
+    /// [`BaseType`](crate::asm::node::signature::BaseType).
     fn visit_base_type(&mut self, char: &char) {}
+    
+    /// Visits array type in signature. Further type visiting is required after 
+    /// [`visit_array_type`](TypeVisitor::visit_array_type) called. For example: you can call this 
+    /// [`visit_array_type`](TypeVisitor::visit_array_type) then call 
+    /// [`visit_base_type`](TypeVisitor::visit_base_type) to construct a base type array.
     fn visit_array_type(&mut self) {}
+    
+    /// Visits class type in signature.
     fn visit_class_type(&mut self, name: &String) {}
+    
+    /// Visits inner class type in signature. Required calling [`visit_class_type`](TypeVisitor::visit_class_type)
+    /// before calling [`visit_inner_class_type`](TypeVisitor::visit_inner_class_type).
     fn visit_inner_class_type(&mut self, name: &String) {}
+    
+    /// Visits type variable in signature.
     fn visit_type_variable(&mut self, name: &String) {}
+    
+    /// Visits type argument in signature. Required calling [visit_class_type](TypeVisitor::visit_class_type)
+    /// before calling [`visit_type_argument`](TypeVisitor::visit_type_argument).
+    /// 
+    /// This function will be called when the following type is unbounded. For type argument with
+    /// wildcard, see [`visit_type_argument_wildcard`](TypeVisitor::visit_type_argument_wildcard) for 
+    /// more info.
     fn visit_type_argument(&mut self) {}
+    
+    /// Visits type type argument with wildcard indicator in signature. Required calling 
+    /// [`visit_class_type`](TypeVisitor::visit_class_type) before calling 
+    /// [`visit_type_argument`](TypeVisitor::visit_type_argument).
     fn visit_type_argument_wildcard(&mut self, wildcard: Wildcard) {}
+
+    /// Finalizes the visitor for further process.
     fn visit_end(&mut self) {}
 }
 

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -140,7 +140,7 @@ pub trait MethodSignatureVisitor: FormalTypeParameterVisitable {
 #[allow(unused_variables)]
 pub trait FormalTypeParameterVisitable {
     /// Visits generic signature's formal type parameter. This could be called by multiple times
-    /// when there's more than 1 formal type parameter declared.
+    /// when there's more than 1 formal type parameters declared.
     fn visit_formal_type_parameter(
         &mut self,
         name: &String,

--- a/src/asm/signature.rs
+++ b/src/asm/signature.rs
@@ -65,14 +65,14 @@ impl TryFrom<&char> for Wildcard {
     }
 }
 
-/// A visitor to visit class generic signature. This trait requires struct also implements 
+/// A visitor to visit class generic signature. This trait requires struct also implements
 /// [FormalTypeParameterVisitable].
-/// 
+///
 /// # Implemented Examples
-/// 
+///
 /// See [ClassSignatureWriter] for more info.
 pub trait ClassSignatureVisitor: FormalTypeParameterVisitable {
-    /// Visits class generic signature's super class type. This would be called on every classes 
+    /// Visits class generic signature's super class type. This would be called on every classes
     /// expect `java.lang.Object`.
     fn visit_super_class(&mut self) -> Box<dyn TypeVisitor + '_> {
         Box::new(SignatureVisitorImpl::default())
@@ -103,7 +103,7 @@ pub trait FieldSignatureVisitor {
     fn visit_end(&mut self) {}
 }
 
-/// A visitor to visit method generic signature. This trait requires struct also implements 
+/// A visitor to visit method generic signature. This trait requires struct also implements
 /// [FormalTypeParameterVisitable].
 ///
 /// # Implemented Examples
@@ -120,7 +120,7 @@ pub trait MethodSignatureVisitor: FormalTypeParameterVisitable {
     fn visit_return_type(&mut self) -> Box<dyn TypeVisitor + '_> {
         Box::new(SignatureVisitorImpl::default())
     }
-    
+
     /// Visits method generic signature's exception type. This could be called by multiple times
     /// when there's more than 1 exception types declared.
     fn visit_exception_type(&mut self) -> Box<dyn TypeVisitor + '_> {
@@ -149,7 +149,7 @@ pub trait FormalTypeParameterVisitable {
     }
 }
 
-/// A visitor to visit formal type parameters in generic signature. 
+/// A visitor to visit formal type parameters in generic signature.
 ///
 /// # Implemented Examples
 ///
@@ -160,13 +160,13 @@ pub trait FormalTypeParameterVisitor {
     fn visit_class_bound(&mut self) -> Box<dyn TypeVisitor + '_> {
         Box::new(SignatureVisitorImpl::default())
     }
-    
+
     /// Visits interface bound in formal type parameter. This could be called by multiple times when
     /// there's more than 1 interface bounds declared.
     fn visit_interface_bound(&mut self) -> Box<dyn TypeVisitor + '_> {
         Box::new(SignatureVisitorImpl::default())
     }
-    
+
     /// Finalizes the visitor for further process.
     fn visit_end(&mut self) {}
 }


### PR DESCRIPTION
This PR finalizes modules metioned in title by adding more doc to structs, traits, and functions to help users track usage.