### PR TITLE
`asm::visitor::signature`: Fully implement all signature visitors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,20 @@
 version = 3
 
 [[package]]
+name = "aquamarine"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df752953c49ce90719c7bf1fc587bc8227aed04732ea0c0f85e5397d7fdbd1a1"
+dependencies = [
+ "include_dir",
+ "itertools",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +166,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "include_dir"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +222,7 @@ dependencies = [
 name = "ka-pi"
 version = "0.1.0"
 dependencies = [
+ "aquamarine",
  "cesu8",
  "either",
  "indexmap",
@@ -290,6 +324,30 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -464,6 +522,12 @@ name = "unicode-segmentation"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ indexmap = { version = "1.9.3", features = ["serde-1"] }
 nom = "7.1.3"
 cesu8 = "1.1.0"
 strum = { version = "0.24.1", features = ["derive"] }
+aquamarine = "0.3.2"
 
 [dev-dependencies]
 insta = { version = "1.28.0", features = ["yaml"] }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Ka-Pi offers several essential modules relates to JVM ecosystem:
 
 - `asm`
   - `node` - Bytecode structure definition module, used by most of other modules.
+  - `visitor` (WIP) - Builtin implementation of visitor pattern based on `node` module.
   - `parse` - Bytecode parsing module used to resolve bytecode (or classfile) into structs.
   - `generate` (WIP) - Bytecode generation module used to generate bytecode.
 
@@ -37,8 +38,18 @@ fn main() -> KapiResult<()> {
 
 ### Implementation Status
 
-#### `asm` 
-- TODO
+#### `node` 
+All nodes described in [The Java® Virtual Machine Specification Java SE 20 Edition](https://docs.oracle.com/javase/specs/jvms/se20/jvms20.pdf)
+are implemented.
+
+#### `visitor`
+- [ ] class visitor
+- [ ] field visitor
+- [ ] method visitor
+- [ ] module visitor
+- [ ] annotation visitor
+- [ ] record visitor
+- [x] Signature visitor
 
 #### `parse`
 <details>
@@ -112,6 +123,20 @@ fn main() -> KapiResult<()> {
     - [x] Custom Attribute (Not described in specification)
 </details>
 
+#### `generate`
+
+- [x] Basic symbol generation
+  - [x] Class
+  - [x] Field
+  - [x] Method
+- [ ] Class
+  - [ ] Class hierarchy analysis
+  - [ ] Accessibility check
+- [x] Field
+- [ ] Method
+  - [ ] Method descriptor type check
+  - [ ] Method stack frame analysis
+  - [ ] `crate::asm::generate::Instruction` based opcode generate functions
 
 ### See also
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ All nodes described in [The Java® Virtual Machine Specification Java SE 20 Edit
 are implemented.
 
 #### `visitor`
-- [ ] class visitor
-- [ ] field visitor
-- [ ] method visitor
-- [ ] module visitor
-- [ ] annotation visitor
-- [ ] record visitor
+- [ ] Class visitor
+- [ ] Field visitor
+- [ ] Method visitor
+- [ ] Module visitor
+- [ ] Annotation visitor
+- [ ] Record visitor
 - [x] Signature visitor
 
 #### `parse`

--- a/assets/flow/signature/class_signature_visitor.mmd
+++ b/assets/flow/signature/class_signature_visitor.mmd
@@ -1,0 +1,9 @@
+flowchart
+    A0[(Entry Point)]
+    A1["< Self as FormalTypeParameterVisitable>::visit_parameter_types"]
+    A2["< Self as FormalTypeParameterVisitable>::visit_parameter_type"]
+    A3[visit_super_class]
+    A4[visit_interfaces]
+    A5[visit_interface]
+    
+    A0 --> A1 --> A2 --> A3 --> A4 --> A5

--- a/assets/flow/signature/field_signature_visitor.mmd
+++ b/assets/flow/signature/field_signature_visitor.mmd
@@ -1,0 +1,5 @@
+flowchart
+    A0[(Entry Point)]
+    A1[visit_field_type]
+    
+    A0 --> A1

--- a/assets/flow/signature/formal_type_parameter_visitable.mmd
+++ b/assets/flow/signature/formal_type_parameter_visitable.mmd
@@ -1,0 +1,7 @@
+flowchart
+    A0[(Entry Point)]
+    A1[visit_formal_types]
+    A2[visit_formal_type]
+    
+    A0 --> A1
+    A1 --> A2

--- a/assets/flow/signature/formal_type_parameter_visitor.mmd
+++ b/assets/flow/signature/formal_type_parameter_visitor.mmd
@@ -1,0 +1,10 @@
+flowchart
+    A0[(Entry Point)]
+    A1[visit_class_bound]
+    A2[visit_interface_bounds]
+    A3[visit_interface_bound]
+    
+    A0 --> A1
+    A1 --> A2
+    A0 --> A2
+    A2 --> A3

--- a/assets/flow/signature/method_signature_visitor.mmd
+++ b/assets/flow/signature/method_signature_visitor.mmd
@@ -1,0 +1,11 @@
+flowchart
+    A0[(Entry Point)]
+    A1["< Self as FormalTypeParameterVisitable>::visit_parameter_types"]
+    A2["< Self as FormalTypeParameterVisitable>::visit_parameter_type"]
+    A3[visit_parameter_types]
+    A4[visit_parameter_type]
+    A5[visit_return_type]
+    A6[visit_exception_types]
+    A7[visit_exception_type]
+    
+    A0 --> A1 --> A2 --> A3 --> A4 --> A5 --> A6 --> A7

--- a/assets/flow/signature/signature_visitor.mmd
+++ b/assets/flow/signature/signature_visitor.mmd
@@ -1,0 +1,9 @@
+flowchart
+    A0[(Entry Point)]
+    B["< Self as ClassSignatureVisitor as FormalTypeParameterVisitor>::visit_formal_types"]
+    C["< Self as FieldSignatureVisitor>::visit_field_type"]
+    D["< Self as MethodSignatureVisitor as FormalTypeParameterVisitor>::visit_formal_types"]
+    
+    A0 -->|Signature::Class| B
+    A0 -->|Signature::Field| C
+    A0 -->|Signature::Method| D

--- a/assets/flow/signature/signature_visitor_all.mmd
+++ b/assets/flow/signature/signature_visitor_all.mmd
@@ -1,0 +1,96 @@
+flowchart
+    subgraph SignatureVisitor
+        SV_A0[(Entry Point)]
+    end
+    
+    subgraph ClassSignatureVisitor
+        CSV_A1{{FormalTypeParameterVisitable}}
+        CSV_A3[visit_super_class]
+        CSV_A4[visit_interfaces]
+        CSV_A5[visit_interface]
+
+        SV_A0 -->|Signature::Class| CSV_A1 --> CSV_A3 --> CSV_A4 --> CSV_A5
+    end
+    
+    subgraph FieldSignatureVisitor
+        FSV_A1[visit_field_type]
+
+        SV_A0 -->|Signature::Field| FSV_A1
+    end
+    
+    subgraph MethodVisitor
+        MV_A1{{FormalTypeParameterVisitable}}
+        MV_A3[visit_parameter_types]
+        MV_A4[visit_parameter_type]
+        MV_A5[visit_return_type]
+        MV_A6[visit_exception_types]
+        MV_A7[visit_exception_type]
+
+        SV_A0 -->|Signature::Method| MV_A1 --> MV_A3 --> MV_A4 --> MV_A5 --> MV_A6 --> MV_A7
+    end
+    
+    subgraph FormalTypeParameterVisitable
+        FTPV0_A1[visit_formal_types]
+        FTPV0_A2[visit_formal_type]
+
+        CSV_A1 & MV_A1 --> FTPV0_A1
+        FTPV0_A1 --> FTPV0_A2
+    end
+    
+    subgraph FormalTypeParameterVisitor
+        FTPV_A1[visit_class_bound]
+        FTPV_A2[visit_interface_bounds]
+        FTPV_A3[visit_interface_bound]
+
+        FTPV0_A2 --> FTPV_A1
+        FTPV_A1 --> FTPV_A2
+        FTPV_A2 --> FTPV_A3
+    end
+    
+    subgraph TypeVisitor
+        TV_TYP_REF{ReferenceType}
+        TV_TYP_SIG{SignatureType}
+        TV_TYP_THR{ThrowsType}
+        TV_TYP_BAS{BaseType}
+        TV_TYP_ARR{ArrayType}
+        TV_TYP_CLS{ClassType}
+        TV_TYP_TYP_VAR{TypeVariable}
+        
+        TV_A1[visit_base_type]
+        TV_A2[visit_class_type]
+        TV_A3[visit_array_type]
+        TV_A4[visit_type_variable]
+        TV_B0[visit_type_arguments]
+        TV_B1[visit_type_argument]
+        TV_B2[visit_type_argument_bound]
+        TV_B3[visit_type_argument_wildcard]
+        TV_C0[visit_inner_classes]
+        TV_C1[visit_inner_class]
+
+        CSV_A3 & CSV_A5 & FTPV_A3 & FTPV_A1 & TV_TYP_REF & TV_B2 & TV_A3 --> TV_TYP_CLS
+
+        FSV_A1 & TV_TYP_SIG & TV_TYP_THR --> TV_TYP_REF
+
+        MV_A4 & MV_A5 --> TV_TYP_SIG
+        MV_A7 --> TV_TYP_THR
+
+        TV_TYP_SIG & TV_A3 --> TV_TYP_BAS
+        TV_TYP_THR --> TV_TYP_TYP_VAR
+        TV_TYP_REF --> TV_TYP_ARR
+        TV_TYP_REF --> TV_TYP_TYP_VAR
+        TV_TYP_BAS --> TV_A1
+        TV_TYP_ARR --> TV_A3
+        TV_TYP_CLS --> TV_A2
+        TV_TYP_TYP_VAR --> TV_A4
+
+        TV_A2 --> TV_B0
+        TV_B0 --> TV_B1
+        TV_B1 --> TV_B2
+        TV_B1 --> TV_B3
+        TV_B2 --> TV_A3 & TV_TYP_TYP_VAR
+
+        TV_A2 --> TV_C0
+        TV_C0 --> TV_C1
+        TV_C1 --> TV_B0
+        TV_C1 --> TV_C0
+    end

--- a/assets/flow/signature/type_visitor_graph.mmd
+++ b/assets/flow/signature/type_visitor_graph.mmd
@@ -1,5 +1,5 @@
 flowchart
-    A0[(Start Visit)]
+    A0[(Entry Point)]
     A1[visit_base_type]
     A2[visit_class_type]
     A3[visit_array_type]
@@ -18,7 +18,6 @@ flowchart
 
     A3 --> A2
     A3 --> A1
-    A3 --> A3
 
     A2 --> B0
     B0 --> B1

--- a/assets/type_visitor_graph.mmd
+++ b/assets/type_visitor_graph.mmd
@@ -1,0 +1,34 @@
+flowchart
+    A0[(Start Visit)]
+    A1[visit_base_type]
+    A2[visit_class_type]
+    A3[visit_array_type]
+    A4[visit_type_variable]
+    B0[visit_type_arguments]
+    B1[visit_type_argument]
+    B2[visit_type_argument_bound]
+    B3[visit_type_argument_wildcard]
+    C0[visit_inner_classes]
+    C1[visit_inner_class]
+
+    A0 --> A1
+    A0 --> A2
+    A0 --> A3
+    A0 --> A4
+
+    A3 --> A2
+    A3 --> A1
+    A3 --> A3
+
+    A2 --> B0
+    B0 --> B1
+    B1 --> B2
+    B1 --> B3
+    B2 --> A2
+    B2 --> A3
+    B2 --> A4
+
+    A2 --> C0
+    C0 --> C1
+    C1 --> B0
+    C1 --> C0

--- a/src/asm/visitor/class.rs
+++ b/src/asm/visitor/class.rs
@@ -9,12 +9,22 @@ pub trait ClassVisitor {
     type CV: ConstantVisitor;
     type MV: MethodVisitor;
     type FV: FieldVisitor;
-    
-    fn visit_version(&mut self, version: &mut JavaVersion);
-    
-    fn visit_constant_pool(&mut self, constant_pool: &mut ConstantPool) -> Self::CV;
-    
-    fn visit_field(&mut self, access_flags: &mut Vec<FieldAccessFlag>, name: &mut String, descriptor: &mut String) -> Self::FV;
 
-    fn visit_method(&mut self, access_flags: &mut Vec<MethodAccessFlag>, name: &mut String, descriptor: &mut String) -> Self::MV;
+    fn visit_version(&mut self, version: &mut JavaVersion);
+
+    fn visit_constant_pool(&mut self, constant_pool: &mut ConstantPool) -> Self::CV;
+
+    fn visit_field(
+        &mut self,
+        access_flags: &mut Vec<FieldAccessFlag>,
+        name: &mut String,
+        descriptor: &mut String,
+    ) -> Self::FV;
+
+    fn visit_method(
+        &mut self,
+        access_flags: &mut Vec<MethodAccessFlag>,
+        name: &mut String,
+        descriptor: &mut String,
+    ) -> Self::MV;
 }

--- a/src/asm/visitor/class.rs
+++ b/src/asm/visitor/class.rs
@@ -1,9 +1,20 @@
 use crate::asm::node::access_flag::{FieldAccessFlag, MethodAccessFlag};
+use crate::asm::node::class::JavaVersion;
+use crate::asm::node::constant::ConstantPool;
+use crate::asm::visitor::constant::ConstantVisitor;
+use crate::asm::visitor::field::FieldVisitor;
+use crate::asm::visitor::method::MethodVisitor;
 
 pub trait ClassVisitor {
-    fn visit_method<F>(&mut self, access_flags: &mut Vec<MethodAccessFlag>, name: &str, descriptor: &str);
+    type CV: ConstantVisitor;
+    type MV: MethodVisitor;
+    type FV: FieldVisitor;
+    
+    fn visit_version(&mut self, version: &mut JavaVersion);
+    
+    fn visit_constant_pool(&mut self, constant_pool: &mut ConstantPool) -> Self::CV;
+    
+    fn visit_field(&mut self, access_flags: &mut Vec<FieldAccessFlag>, name: &mut String, descriptor: &mut String) -> Self::FV;
 
-    fn visit_field<F>(&mut self, access_flags: &mut Vec<FieldAccessFlag>, name: &mut str, descriptor: &str);
-
-    fn visit_end(&mut self) {}
+    fn visit_method(&mut self, access_flags: &mut Vec<MethodAccessFlag>, name: &mut String, descriptor: &mut String) -> Self::MV;
 }

--- a/src/asm/visitor/class.rs
+++ b/src/asm/visitor/class.rs
@@ -1,13 +1,9 @@
 use crate::asm::node::access_flag::{FieldAccessFlag, MethodAccessFlag};
 
 pub trait ClassVisitor {
-    fn visit_method<F>(&mut self, access_flags: F, name: &str, descriptor: &str)
-    where
-        F: IntoIterator<Item = MethodAccessFlag>;
+    fn visit_method<F>(&mut self, access_flags: &mut Vec<MethodAccessFlag>, name: &str, descriptor: &str);
 
-    fn visit_field<F>(&mut self, access_flags: F, name: &str, descriptor: &str)
-    where
-        F: IntoIterator<Item = FieldAccessFlag>;
+    fn visit_field<F>(&mut self, access_flags: &mut Vec<FieldAccessFlag>, name: &mut str, descriptor: &str);
 
     fn visit_end(&mut self) {}
 }

--- a/src/asm/visitor/constant.rs
+++ b/src/asm/visitor/constant.rs
@@ -1,0 +1,3 @@
+pub trait ConstantVisitor {
+    
+}

--- a/src/asm/visitor/constant.rs
+++ b/src/asm/visitor/constant.rs
@@ -1,3 +1,1 @@
-pub trait ConstantVisitor {
-    
-}
+pub trait ConstantVisitor {}

--- a/src/asm/visitor/field.rs
+++ b/src/asm/visitor/field.rs
@@ -3,6 +3,4 @@ use crate::error::KapiResult;
 
 pub trait FieldVisitor {
     fn visit_constant(&mut self, constant_value: ConstantValue) -> KapiResult<()>;
-
-    fn visit_end(&mut self) {}
 }

--- a/src/asm/visitor/method.rs
+++ b/src/asm/visitor/method.rs
@@ -1,2 +1,1 @@
-pub trait MethodVisitor {
-}
+pub trait MethodVisitor {}

--- a/src/asm/visitor/method.rs
+++ b/src/asm/visitor/method.rs
@@ -1,3 +1,2 @@
 pub trait MethodVisitor {
-    fn visit_end(&mut self) {}
 }

--- a/src/asm/visitor/mod.rs
+++ b/src/asm/visitor/mod.rs
@@ -1,9 +1,9 @@
 pub mod class;
+pub mod constant;
 pub mod field;
 pub mod method;
 pub mod module;
 pub mod signature;
-pub mod constant;
 
 pub trait Visitable<V> {
     fn visit(&mut self, visitor: &mut V);

--- a/src/asm/visitor/mod.rs
+++ b/src/asm/visitor/mod.rs
@@ -3,6 +3,7 @@ pub mod field;
 pub mod method;
 pub mod module;
 pub mod signature;
+pub mod constant;
 
 pub trait Visitable<V> {
     fn visit(&mut self, visitor: &mut V);

--- a/src/asm/visitor/signature.rs
+++ b/src/asm/visitor/signature.rs
@@ -1,35 +1,99 @@
-use crate::asm::node::signature::BaseType;
-use crate::asm::node::signature::WildcardIndicator;
+use crate::asm::node::signature::{FormalTypeParameter, ReferenceType, SignatureType, ThrowsType, WildcardIndicator};
+use crate::asm::node::signature::{ArrayType, BaseType, ClassType, TypeArgument};
 
 pub trait SignatureVisitor {
     type TV: TypeVisitor;
     type FTPV: FormalTypeParameterVisitor;
 
-    /// Visits class generic signature's super class type. This would be called on every classes
-    /// expect `java.lang.Object`.
-    fn visit_super_class(&mut self) -> Self::TV;
+    /// Visits class generic signature's super class type. 
+    /// 
+    /// # Visit rule
+    /// 
+    /// Consider class signature `Ljava/lang/Object;java/lang/Runnable;java/lang/AutoCloseable`,
+    /// parameter `super_class` will be `java/lang/Object`, then super class type will be visited by
+    /// [TypeVisitor].
+    /// 
+    /// This would be called on every class type except `java/lang/Object` which does not have any
+    /// super type.
+    fn visit_super_class(&mut self, super_class: &mut ClassType) -> Self::TV;
 
-    /// Visits class generic signature's interface type. This could be called by multiple times
-    /// when there's more than 1 interfaces implemented.
-    fn visit_interface(&mut self) -> Self::TV;
+    /// Visits class generic signature's interface types. 
+    ///
+    /// # Visit rule
+    ///
+    /// Consider class signature `Ljava/lang/Object;java/lang/Runnable;java/lang/AutoCloseable`,
+    /// parameter `interfaces` will be `[java/lang/Runnable, java/lang/AutoCloseable]`, then 
+    /// interface types will be visited by [Self::visit_interface].
+    fn visit_interfaces(&mut self, interfaces: &mut Vec<ClassType>);
+    
+    /// Visits class generic signature's interface type. 
+    /// 
+    /// # Visit rule
+    /// 
+    /// Consider class signature `Ljava/lang/Object;java/lang/Runnable;java/lang/AutoCloseable`,
+    /// parameter `interface` will be `java/lang/Runnable` and `java/lang/AutoCloseable`, then 
+    /// interface types will be visited by [TypeVisitor].
+    fn visit_interface(&mut self, interface: &mut ClassType) -> Self::TV;
 
     /// Visits field generic signature's type.
-    fn visit_field_type(&mut self) -> Self::TV;
+    /// 
+    /// # Visit rule
+    /// 
+    /// Consider field signature `Ljava/lang/String;`, parameter `field_type` will be [ClassType] 
+    /// `java/lang/String`, then the type will be visited by [TypeVisitor].
+    fn visit_field_type(&mut self, field_type: &mut ReferenceType) -> Self::TV;
 
-    /// Visits method generic signature's parameter type. This could be called by multiple times
-    /// when there's more than 1 parameters declared.
-    fn visit_parameter_type(&mut self) -> Self::TV;
+    /// Visits method generic signature's parameter types.
+    ///
+    /// # Visit rule
+    ///
+    /// Consider method signature `(Ljava/lang/Object;I)I`, parameter `parameter_types` will be
+    /// `[java/lang/Object, I]`, then parameter types will be visited by [Self::visit_parameter_type].
+    fn visit_parameter_types(&mut self, parameter_types: &mut Vec<SignatureType>);
 
-    /// Visits method generic signature's return type. This would be only called once per method.
-    fn visit_return_type(&mut self) -> Self::TV;
+    /// Visits method generic signature's parameter type.
+    /// 
+    /// # Visit rule
+    /// 
+    /// Consider method signature `(Ljava/lang/Object;I)I`, parameter `parameter_type` will be
+    /// [ClassType] `java/lang/Object` and [BaseType] `I`, then parameter types will be visited by
+    /// [TypeVisitor].
+    fn visit_parameter_type(&mut self, parameter_type: &mut SignatureType) -> Self::TV;
 
-    /// Visits method generic signature's exception type. This could be called by multiple times
-    /// when there's more than 1 exception types declared.
-    fn visit_exception_type(&mut self) -> Self::TV;
+    /// Visits method generic signature's return type.
+    /// 
+    /// # Visit rule
+    /// 
+    /// Consider method signature `(Ljava/lang/Object;I)I`, parameter `return_type` will be
+    /// [BaseType] `I`, then return type will be visited by [TypeVisitor].
+    fn visit_return_type(&mut self, return_type: &mut SignatureType) -> Self::TV;
 
-    /// Visits generic signature's formal type parameter. This could be called by multiple times
-    /// when there's more than 1 formal type parameters declared.
-    fn visit_formal_type_parameter(&mut self, name: &mut String) -> Self::FTPV;
+    /// Visits method generic signature's exception types.
+    ///
+    /// # Visit rule
+    ///
+    /// Consider method signature `()V^TT1;^TT2;`, parameter `throws_types` will be `[T1, T2]`, then 
+    /// throws types will be visited by [Self::visit_exception_type].
+    fn visit_exception_types(&mut self, throws_types: &mut Vec<ThrowsType>);
+    
+    /// Visits method generic signature's exception type.
+    /// 
+    /// # Visit rule
+    /// 
+    /// Consider method signature `()V^TT;`, parameter `throws_type` will be
+    /// [TypeVariable](crate::asm::node::signature::TypeVariable) `T`, then throws type will be
+    /// visited by [TypeVisitor].
+    fn visit_exception_type(&mut self, throws_type: &mut ThrowsType) -> Self::TV;
+
+    /// Visits generic signature's formal type parameters.
+    ///
+    /// # Visit rule
+    fn visit_formal_type_parameters(&mut self, formal_type_parameters: &mut Vec<FormalTypeParameter>);
+
+    /// Visits generic signature's formal type parameter.
+    /// 
+    /// # Visit rule
+    fn visit_formal_type_parameter(&mut self, formal_type_parameter: &mut FormalTypeParameter) -> Self::FTPV;
 }
 
 /// A visitor to visit formal type parameters in generic signature.
@@ -42,26 +106,157 @@ pub trait FormalTypeParameterVisitor {
     fn visit_interface_bound(&mut self) -> Self::TV;
 }
 
+#[cfg_attr(doc, aquamarine::aquamarine)]
 /// A visitor to visit types in generic signature.
+///
+/// # Visit strategy
+/// ```mermaid
+/// flowchart
+///     A0[(Start Visit)]
+///     A1[visit_base_type]
+///     A2[visit_class_type]
+///     A3[visit_array_type]
+///     A4[visit_type_variable]
+///     B0[visit_type_arguments]
+///     B1[visit_type_argument]
+///     B2[visit_type_argument_bound]
+///     B3[visit_type_argument_wildcard]
+///     C0[visit_inner_classes]
+///     C1[visit_inner_class]
+///     
+///     A0 --> A1
+///     A0 --> A2
+///     A0 --> A3
+///     A0 --> A4
+///
+///     A3 --> A2
+///     A3 --> A1
+///     A3 --> A3
+///
+///     A2 --> B0
+///     B0 --> B1
+///     B1 --> B2
+///     B1 --> B3
+///     B2 --> A2
+///     B2 --> A3
+///     B2 --> A4
+///
+///     A2 --> C0
+///     C0 --> C1
+///     C1 --> B0
+///     C1 --> C0
+/// ```
 #[allow(unused_variables)]
 pub trait TypeVisitor {
+    /// Visits [BaseType].
+    ///
+    /// # Visit rule
+    ///
+    /// Consider primitive type `I`, parameter `base_type` will be [BaseType::Int], since [BaseType]
+    /// is guaranteed to be an terminal node of the signature, no more visiting will be occurred on
+    /// this type.
     fn visit_base_type(&mut self, base_type: &mut BaseType) {}
 
-    fn visit_array_type(&mut self) {}
+    /// Visits [ArrayType].
+    ///
+    /// # Visit rule
+    ///
+    /// Consider type `[[example/Class[TT1;].InnerClass[TT2;]`, parameter `array_type` will be same
+    /// as the type given, and the base type will be visited by other visit functions if satisfied.
+    fn visit_array_type(&mut self, array_type: &mut ArrayType) {}
 
-    fn visit_class_type(&mut self, package_path: &mut String, class_name: &mut String) {}
+    /// Visits [ClassType].
+    ///
+    /// # Visit rule
+    ///
+    /// Consider class path `example/Class.InnerClass[TT1;].InnerMostClass[TT2;]`, parameter `class_type` 
+    /// will be `example/Class`, the type arguments of the class type will be visited by 
+    /// [Self::visit_type_arguments] and [Self::visit_type_argument]. And inner classes will be visited 
+    /// by [Self::visit_inner_class_types] and [Self::visit_inner_class_type].
+    fn visit_class_type(&mut self, class_type: &mut ClassType) {}
+    
+    /// Visits type variable [TypeVariable](crate::asm::node::signature::TypeVariable).
+    /// 
+    /// # Visit rule
+    /// 
+    /// Consider type variable `TT;` parameter `name` will be `"T"`, since 
+    /// [TypeVariable](crate::asm::node::signature::TypeVariable) is guaranteed to be an terminal node 
+    /// of the signature, no more visiting will be occurred on this type.
+    fn visit_type_variable(&mut self, name: &mut String) {}
+    
+    /// Visits inner classes of [ClassType].
+    ///
+    /// # Visit rule
+    ///
+    /// Consider class path `example/Class.InnerClass[TT1;].InnerMostClass[TT2;]`, parameter
+    /// `inner_classes` will be `[InnerClass[TT1;], InnerMostClass[TT2;]]`, and type arguments of both 
+    /// inner classes will be visited by [Self::visit_type_arguments] in order.
+    fn visit_inner_class_types(&mut self, inner_classes: &mut Vec<(String, Vec<TypeArgument>)>) {}
 
+    /// Visits inner class of [ClassType].
+    ///
+    /// # Visit rule
+    ///
+    /// Consider class path `example/Class.InnerClass[TT1;].InnerMostClass[TT2;]`, parameter
+    /// `name` will be `InnerClass` and `InnerMostClass` in order in different calls. and their type
+    /// parameters of both inner classes will be visited by [Self::visit_type_arguments] in order.
     fn visit_inner_class_type(&mut self, name: &mut String) {}
 
-    fn visit_type_variable(&mut self, name: &mut String) {}
+    /// Visits all [TypeArgument] of [ClassType] or its inner class type.
+    ///
+    /// # Visit rule
+    /// 
+    /// Consider type argument signature `[TT1;TT2;]`, parameter `type_arguments` will be `[T1, T2]`,
+    /// then each type arguments will be visited by [Self::visit_type_argument].
+    fn visit_type_arguments(&mut self, type_arguments: &mut Vec<TypeArgument>) {}
 
-    fn visit_type_argument_bounded(&mut self, wildcard: &mut WildcardIndicator) {}
+    /// Visits [TypeArgument].
+    /// 
+    /// # Visit rule
+    /// 
+    /// Consider type argument `[+Ljava/lang/Object;]`, parameter `type_argument` will be `java/lang/Object`,
+    /// then the type argument will be visited by either [Self::visit_type_argument_bounded] or 
+    /// [Self::visit_type_argument_wildcard].
+    fn visit_type_argument(&mut self, type_argument: &mut TypeArgument) {}
 
+    /// Visits [TypeArgument::Bounded].
+    /// 
+    /// # Visit rule
+    /// 
+    /// Consider type argument `[+Ljava/lang/Object;]`, parameter `wildcard` will be 
+    /// [WildcardIndicator::EXTENDS], and parameter `reference_type` will be `java/lang/Object`,
+    /// them the `reference_type` will be visited by either [Self::visit_array_type], 
+    /// [Self::visit_class_type], or [Self::visit_type_variable].
+    fn visit_type_argument_bounded(&mut self, wildcard: &mut WildcardIndicator, reference_type: &mut ReferenceType) {}
+
+    /// Visits [TypeArgument::Wildcard].
+    /// 
+    /// # Visit rule
+    /// 
+    /// It is guaranteed that this function will only visit type argument `[*]`, as known as wildcard,
+    /// and no more visiting will be occurred.
+    /// 
+    /// # Mutation
+    /// 
+    /// To mutate type argument itself, use [Self::visit_type_argument].
     fn visit_type_argument_wildcard(&mut self) {}
 }
 
-/// Default signature visitor for internal usage only. This visitor does not have any effect on visiting
-/// signatures.
+/// Default signature visitor implementation This visitor is meant to used in non-behavioral situations.
+/// 
+/// # Usage
+/// While implementing a signature visitor, you need to specify children visitor's implementation as
+/// well, sometimes you may not want to do anything with children visitor, to avoid this, you can use
+/// [SignatureVisitorImpl].
+/// 
+/// ```rust
+/// use ka_pi::asm::visitor::signature::SignatureVisitor;
+/// 
+/// #[derive(Default)]
+/// pub struct ExampleVisitor {
+///     // ...
+/// }
+/// ```
 #[derive(Debug, Default)]
 pub struct SignatureVisitorImpl {}
 
@@ -69,31 +264,47 @@ impl SignatureVisitor for SignatureVisitorImpl {
     type TV = Self;
     type FTPV = Self;
 
-    fn visit_super_class(&mut self) -> Self::TV {
-        Self::default()
+    fn visit_super_class(&mut self, super_class: &mut ClassType) -> Self::TV {
+        todo!()
     }
 
-    fn visit_interface(&mut self) -> Self::TV {
-        Self::default()
+    fn visit_interfaces(&mut self, interfaces: &mut Vec<ClassType>) {
+        todo!()
     }
 
-    fn visit_field_type(&mut self) -> Self::TV {
-        Self::default()
+    fn visit_interface(&mut self, interface: &mut ClassType) -> Self::TV {
+        todo!()
     }
 
-    fn visit_parameter_type(&mut self) -> Self::TV {
-        Self::default()
+    fn visit_field_type(&mut self, field_type: &mut ReferenceType) -> Self::TV {
+        todo!()
     }
 
-    fn visit_return_type(&mut self) -> Self::TV {
-        Self::default()
+    fn visit_parameter_types(&mut self, parameter_types: &mut Vec<SignatureType>) {
+        todo!()
     }
 
-    fn visit_exception_type(&mut self) -> Self::TV {
-        Self::default()
+    fn visit_parameter_type(&mut self, parameter_type: &mut SignatureType) -> Self::TV {
+        todo!()
     }
 
-    fn visit_formal_type_parameter(&mut self, _: &mut String) -> Self::FTPV {
+    fn visit_return_type(&mut self, return_type: &mut SignatureType) -> Self::TV {
+        todo!()
+    }
+
+    fn visit_exception_types(&mut self, throws_types: &mut Vec<ThrowsType>) {
+        todo!()
+    }
+
+    fn visit_exception_type(&mut self, throws_type: &mut ThrowsType) -> Self::TV {
+        todo!()
+    }
+
+    fn visit_formal_type_parameters(&mut self, formal_type_parameters: &mut Vec<FormalTypeParameter>) {
+        todo!()
+    }
+
+    fn visit_formal_type_parameter(&mut self, _: &mut FormalTypeParameter) -> Self::FTPV {
         Self::default()
     }
 }

--- a/src/asm/visitor/signature.rs
+++ b/src/asm/visitor/signature.rs
@@ -1,113 +1,364 @@
-use crate::asm::node::signature::{FormalTypeParameter, ReferenceType, SignatureType, ThrowsType, WildcardIndicator};
-use crate::asm::node::signature::{ArrayType, BaseType, ClassType, TypeArgument};
+use crate::asm::node::signature::{ArrayType, BaseType, ClassType, Signature, TypeArgument};
+use crate::asm::node::signature::{
+    FormalTypeParameter, ReferenceType, SignatureType, ThrowsType, WildcardIndicator,
+};
 
-pub trait SignatureVisitor {
-    type TV: TypeVisitor;
-    type FTPV: FormalTypeParameterVisitor;
+#[cfg_attr(doc, aquamarine::aquamarine)]
+/// A general signature visitor for visiting [Signature](Signature).
+///
+/// # Visit strategy overview
+/// ```mermaid
+/// flowchart
+///     subgraph SignatureVisitor
+///         SV_A0[(Entry Point)]
+///     end
+///     
+///     subgraph ClassSignatureVisitor
+///         CSV_A1{{FormalTypeParameterVisitable}}
+///         CSV_A3[visit_super_class]
+///         CSV_A4[visit_interfaces]
+///         CSV_A5[visit_interface]
+///
+///         SV_A0 -->|Signature::Class| CSV_A1 --> CSV_A3 --> CSV_A4 --> CSV_A5
+///     end
+///     
+///     subgraph FieldSignatureVisitor
+///         FSV_A1[visit_field_type]
+///
+///         SV_A0 -->|Signature::Field| FSV_A1
+///     end
+///     
+///     subgraph MethodVisitor
+///         MV_A1{{FormalTypeParameterVisitable}}
+///         MV_A3[visit_parameter_types]
+///         MV_A4[visit_parameter_type]
+///         MV_A5[visit_return_type]
+///         MV_A6[visit_exception_types]
+///         MV_A7[visit_exception_type]
+///
+///         SV_A0 -->|Signature::Method| MV_A1 --> MV_A3 --> MV_A4 --> MV_A5 --> MV_A6 --> MV_A7
+///     end
+///     
+///     subgraph FormalTypeParameterVisitable
+///         FTPV0_A1[visit_formal_types]
+///         FTPV0_A2[visit_formal_type]
+///
+///         CSV_A1 & MV_A1 --> FTPV0_A1
+///         FTPV0_A1 --> FTPV0_A2
+///     end
+///     
+///     subgraph FormalTypeParameterVisitor
+///         FTPV_A1[visit_class_bound]
+///         FTPV_A2[visit_interface_bounds]
+///         FTPV_A3[visit_interface_bound]
+///
+///         FTPV0_A2 --> FTPV_A1
+///         FTPV_A1 --> FTPV_A2
+///         FTPV_A2 --> FTPV_A3
+///     end
+///     
+///     subgraph TypeVisitor
+///         TV_TYP_REF{ReferenceType}
+///         TV_TYP_SIG{SignatureType}
+///         TV_TYP_THR{ThrowsType}
+///         TV_TYP_BAS{BaseType}
+///         TV_TYP_ARR{ArrayType}
+///         TV_TYP_CLS{ClassType}
+///         TV_TYP_TYP_VAR{TypeVariable}
+///         
+///         TV_A1[visit_base_type]
+///         TV_A2[visit_class_type]
+///         TV_A3[visit_array_type]
+///         TV_A4[visit_type_variable]
+///         TV_B0[visit_type_arguments]
+///         TV_B1[visit_type_argument]
+///         TV_B2[visit_type_argument_bound]
+///         TV_B3[visit_type_argument_wildcard]
+///         TV_C0[visit_inner_classes]
+///         TV_C1[visit_inner_class]
+///
+///         CSV_A3 & CSV_A5 & FTPV_A3 & FTPV_A1 & TV_TYP_REF & TV_B2 & TV_A3 --> TV_TYP_CLS
+///
+///         FSV_A1 & TV_TYP_SIG & TV_TYP_THR --> TV_TYP_REF
+///
+///         MV_A4 & MV_A5 --> TV_TYP_SIG
+///         MV_A7 --> TV_TYP_THR
+///
+///         TV_TYP_SIG & TV_A3 --> TV_TYP_BAS
+///         TV_TYP_THR --> TV_TYP_TYP_VAR
+///         TV_TYP_REF --> TV_TYP_ARR
+///         TV_TYP_REF --> TV_TYP_TYP_VAR
+///         TV_TYP_BAS --> TV_A1
+///         TV_TYP_ARR --> TV_A3
+///         TV_TYP_CLS --> TV_A2
+///         TV_TYP_TYP_VAR --> TV_A4
+///
+///         TV_A2 --> TV_B0
+///         TV_B0 --> TV_B1
+///         TV_B1 --> TV_B2
+///         TV_B1 --> TV_B3
+///         TV_B2 --> TV_A3 & TV_TYP_TYP_VAR
+///
+///         TV_A2 --> TV_C0
+///         TV_C0 --> TV_C1
+///         TV_C1 --> TV_B0
+///         TV_C1 --> TV_C0
+///     end
+/// ```
+pub trait SignatureVisitor:
+    ClassSignatureVisitor + FieldSignatureVisitor + MethodSignatureVisitor
+{
+}
 
-    /// Visits class generic signature's super class type. 
-    /// 
+#[cfg_attr(doc, aquamarine::aquamarine)]
+/// Visitor used for visiting [Signature::Class].
+///
+/// # Visit strategy
+/// ```mermaid
+/// flowchart
+///     A0[(Entry Point)]
+///     A1["< Self as FormalTypeParameterVisitable>::visit_parameter_types"]
+///     A2["< Self as FormalTypeParameterVisitable>::visit_parameter_type"]
+///     A3[visit_super_class]
+///     A4[visit_interfaces]
+///     A5[visit_interface]
+///     
+///     A0 --> A1 --> A2 --> A3 --> A4 --> A5
+/// ```
+pub trait ClassSignatureVisitor: FormalTypeParameterVisitable {
+    /// Type visitor for super class visiting.
+    type SCTV: TypeVisitor;
+    /// Type visitor for interface visiting.
+    type ITV: TypeVisitor;
+
+    /// Visits class signature's super class type.
+    ///
     /// # Visit rule
-    /// 
+    ///
     /// Consider class signature `Ljava/lang/Object;java/lang/Runnable;java/lang/AutoCloseable`,
     /// parameter `super_class` will be `java/lang/Object`, then super class type will be visited by
-    /// [TypeVisitor].
-    /// 
+    /// [TypeVisitor] provided by [Self::SCTV].
+    ///
     /// This would be called on every class type except `java/lang/Object` which does not have any
     /// super type.
-    fn visit_super_class(&mut self, super_class: &mut ClassType) -> Self::TV;
+    fn visit_super_class(&mut self, super_class: &mut ClassType) -> Self::SCTV;
 
-    /// Visits class generic signature's interface types. 
+    //noinspection RsLiveness
+    /// Visits class signature's interface types.
     ///
     /// # Visit rule
     ///
     /// Consider class signature `Ljava/lang/Object;java/lang/Runnable;java/lang/AutoCloseable`,
-    /// parameter `interfaces` will be `[java/lang/Runnable, java/lang/AutoCloseable]`, then 
+    /// parameter `interfaces` will be `[java/lang/Runnable, java/lang/AutoCloseable]`, then
     /// interface types will be visited by [Self::visit_interface].
-    fn visit_interfaces(&mut self, interfaces: &mut Vec<ClassType>);
-    
-    /// Visits class generic signature's interface type. 
-    /// 
+    fn visit_interfaces(&mut self, interfaces: &mut Vec<ClassType>) {}
+
+    /// Visits class signature's interface type.
+    ///
     /// # Visit rule
-    /// 
+    ///
     /// Consider class signature `Ljava/lang/Object;java/lang/Runnable;java/lang/AutoCloseable`,
-    /// parameter `interface` will be `java/lang/Runnable` and `java/lang/AutoCloseable`, then 
-    /// interface types will be visited by [TypeVisitor].
-    fn visit_interface(&mut self, interface: &mut ClassType) -> Self::TV;
+    /// parameter `interface` will be `java/lang/Runnable` and `java/lang/AutoCloseable`, then
+    /// interface types will be visited by [TypeVisitor] provided by [Self::ITV].
+    fn visit_interface(&mut self, interface: &mut ClassType) -> Self::ITV;
+}
 
-    /// Visits field generic signature's type.
-    /// 
+#[cfg_attr(doc, aquamarine::aquamarine)]
+/// Visitor used for visiting [Signature::Field].
+///
+/// # Visit strategy
+/// ```mermaid
+/// flowchart
+///     A0[(Entry Point)]
+///     A1[visit_field_type]
+///     
+///     A0 --> A1
+/// ```
+pub trait FieldSignatureVisitor {
+    /// Type visitor for field type visiting.
+    type FTV: TypeVisitor;
+
+    /// Visits field signature's type.
+    ///
     /// # Visit rule
-    /// 
-    /// Consider field signature `Ljava/lang/String;`, parameter `field_type` will be [ClassType] 
-    /// `java/lang/String`, then the type will be visited by [TypeVisitor].
-    fn visit_field_type(&mut self, field_type: &mut ReferenceType) -> Self::TV;
+    ///
+    /// Consider field signature `Ljava/lang/String;`, parameter `field_type` will be [ClassType]
+    /// `java/lang/String`, then the type will be visited by [TypeVisitor] provided by [Self::FTV].
+    fn visit_field_type(&mut self, field_type: &mut ReferenceType) -> Self::FTV;
+}
 
-    /// Visits method generic signature's parameter types.
+#[cfg_attr(doc, aquamarine::aquamarine)]
+/// Visitor used for visiting [Signature::Method].
+///
+/// # Visit strategy
+/// ```mermaid
+/// flowchart
+///     A0[(Entry Point)]
+///     A1["< Self as FormalTypeParameterVisitable>::visit_parameter_types"]
+///     A2["< Self as FormalTypeParameterVisitable>::visit_parameter_type"]
+///     A3[visit_parameter_types]
+///     A4[visit_parameter_type]
+///     A5[visit_return_type]
+///     A6[visit_exception_types]
+///     A7[visit_exception_type]
+///     
+///     A0 --> A1 --> A2 --> A3 --> A4 --> A5 --> A6 --> A7
+/// ```
+pub trait MethodSignatureVisitor: FormalTypeParameterVisitable {
+    /// Type visitor for parameter types visiting.
+    type PTV: TypeVisitor;
+    /// Type visitor for return type visiting.
+    type RTV: TypeVisitor;
+    /// Type visitor for exception type visiting.
+    type ETV: TypeVisitor;
+
+    //noinspection RsLiveness
+    /// Visits method signature's parameter types.
     ///
     /// # Visit rule
     ///
     /// Consider method signature `(Ljava/lang/Object;I)I`, parameter `parameter_types` will be
     /// `[java/lang/Object, I]`, then parameter types will be visited by [Self::visit_parameter_type].
-    fn visit_parameter_types(&mut self, parameter_types: &mut Vec<SignatureType>);
+    fn visit_parameter_types(&mut self, parameter_types: &mut Vec<SignatureType>) {}
 
-    /// Visits method generic signature's parameter type.
-    /// 
+    /// Visits method signature's parameter type.
+    ///
     /// # Visit rule
-    /// 
+    ///
     /// Consider method signature `(Ljava/lang/Object;I)I`, parameter `parameter_type` will be
     /// [ClassType] `java/lang/Object` and [BaseType] `I`, then parameter types will be visited by
-    /// [TypeVisitor].
-    fn visit_parameter_type(&mut self, parameter_type: &mut SignatureType) -> Self::TV;
+    /// [TypeVisitor] provided by [Self::PTV].
+    fn visit_parameter_type(&mut self, parameter_type: &mut SignatureType) -> Self::PTV;
 
     /// Visits method generic signature's return type.
-    /// 
+    ///
     /// # Visit rule
-    /// 
+    ///
     /// Consider method signature `(Ljava/lang/Object;I)I`, parameter `return_type` will be
-    /// [BaseType] `I`, then return type will be visited by [TypeVisitor].
-    fn visit_return_type(&mut self, return_type: &mut SignatureType) -> Self::TV;
+    /// [BaseType] `I`, then return type will be visited by [TypeVisitor] provided by [Self::RTV].
+    fn visit_return_type(&mut self, return_type: &mut SignatureType) -> Self::RTV;
 
-    /// Visits method generic signature's exception types.
+    //noinspection RsLiveness
+    /// Visits method signature's exception types.
     ///
     /// # Visit rule
     ///
-    /// Consider method signature `()V^TT1;^TT2;`, parameter `throws_types` will be `[T1, T2]`, then 
+    /// Consider method signature `()V^TT1;^TT2;`, parameter `throws_types` will be `[T1, T2]`, then
     /// throws types will be visited by [Self::visit_exception_type].
-    fn visit_exception_types(&mut self, throws_types: &mut Vec<ThrowsType>);
-    
-    /// Visits method generic signature's exception type.
-    /// 
+    fn visit_exception_types(&mut self, throws_types: &mut Vec<ThrowsType>) {}
+
+    /// Visits method signature's exception type.
+    ///
     /// # Visit rule
-    /// 
+    ///
     /// Consider method signature `()V^TT;`, parameter `throws_type` will be
     /// [TypeVariable](crate::asm::node::signature::TypeVariable) `T`, then throws type will be
-    /// visited by [TypeVisitor].
-    fn visit_exception_type(&mut self, throws_type: &mut ThrowsType) -> Self::TV;
-
-    /// Visits generic signature's formal type parameters.
-    ///
-    /// # Visit rule
-    fn visit_formal_type_parameters(&mut self, formal_type_parameters: &mut Vec<FormalTypeParameter>);
-
-    /// Visits generic signature's formal type parameter.
-    /// 
-    /// # Visit rule
-    fn visit_formal_type_parameter(&mut self, formal_type_parameter: &mut FormalTypeParameter) -> Self::FTPV;
-}
-
-/// A visitor to visit formal type parameters in generic signature.
-#[allow(unused_variables)]
-pub trait FormalTypeParameterVisitor {
-    type TV: TypeVisitor;
-
-    fn visit_class_bound(&mut self) -> Self::TV;
-
-    fn visit_interface_bound(&mut self) -> Self::TV;
+    /// visited by [TypeVisitor] provided by [Self::ETV].
+    fn visit_exception_type(&mut self, throws_type: &mut ThrowsType) -> Self::ETV;
 }
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
-/// A visitor to visit types in generic signature.
+/// Marks visitor that has [FormalTypeParameter] to visit.
+///
+/// # Visit strategy
+/// ```mermaid
+/// flowchart
+///     A0[(Entry Point)]
+///     A1[visit_formal_types]
+///     A2[visit_formal_type]
+///     
+///     A0 --> A1
+///     A1 --> A2
+/// ```
+pub trait FormalTypeParameterVisitable {
+    /// Type visitor for formal type parameter visiting.
+    type FTPV: FormalTypeParameterVisitor;
+
+    //noinspection RsLiveness
+    /// Visits signature's formal type parameters.
+    ///
+    /// # Visit rule
+    ///
+    /// Consider formal type parameters `[T:R:]`, parameter `formal_type_parameters` will be
+    /// `[T, R]`, then formal type parameters will be visited by [Self::visit_formal_type_parameter].
+    fn visit_formal_type_parameters(
+        &mut self,
+        formal_type_parameters: &mut Vec<FormalTypeParameter>,
+    ) {
+    }
+
+    /// Visits signature's formal type parameter.
+    ///
+    /// # Visit rule
+    ///
+    /// Consider formal type parameters `[T:R:]`, parameter `formal_type_parameter` will be
+    /// [TypeVariable](crate::asm::node::signature::TypeVariable) `T` and `R`, then formal type
+    /// parameters will be visited by [TypeVisitor] provided by [Self::FTPV].
+    fn visit_formal_type_parameter(
+        &mut self,
+        formal_type_parameter: &mut FormalTypeParameter,
+    ) -> Self::FTPV;
+}
+
+#[cfg_attr(doc, aquamarine::aquamarine)]
+/// Visitor used for visiting [FormalTypeParameter].
+///
+/// # Visit strategy
+/// ```mermaid
+/// flowchart
+///     A0[(Entry Point)]
+///     A1[visit_class_bound]
+///     A2[visit_interface_bounds]
+///     A3[visit_interface_bound]
+///     
+///     A0 --> A1
+///     A1 --> A2
+///     A0 --> A2
+///     A2 --> A3
+/// ```
+pub trait FormalTypeParameterVisitor {
+    /// Type visitor for class bound type visiting.
+    type CBTV: TypeVisitor;
+    /// Type visitor for interface bound type visiting.
+    type IBTV: TypeVisitor;
+
+    /// Visits formal type parameter's class bound if exists.
+    ///
+    /// # Visit rule
+    ///
+    /// ## When class bound exists
+    ///
+    /// Consider formal type parameter `T:Ljava/lang/Object;`, parameter `class_bound_type` will be
+    /// [ClassType] `java/lang/Object`, then class bound type will be visited by [TypeVisitor] provided
+    /// by [Self::CBTV].
+    ///
+    /// ## when class bound does not exists
+    ///
+    /// Consider formal type parameter `T:`, then [Self::visit_class_bound] will not be called.
+    fn visit_class_bound(&mut self, class_bound_type: &mut ClassType) -> Self::CBTV;
+
+    //noinspection RsLiveness
+    /// Visits formal type parameter's interface bounds.
+    ///
+    /// # Visit rule
+    ///
+    /// Consider formal type parameter `T::Ljava/lang/Runnable;:Ljava/lang/AutoCloseable;`, parameter
+    /// `interface_bound_types` will be `[java/lang/Runnable, java/lang/AutoCloseable]`, then interface
+    /// bound types will be visited by [Self::visit_interface_bound].
+    fn visit_interface_bounds(&mut self, interface_bound_types: &mut Vec<ClassType>) {}
+
+    /// Visits formal type parameter's interface bound.
+    ///
+    /// # Visit rule
+    ///
+    /// Consider formal type parameter `T::Ljava/lang/Runnable;:Ljava/lang/AutoCloseable;`, parameter
+    /// `interface_bound_type` will be [ClassType] `java/lang/Runnable` and `java/lang/AutoCloseable`,
+    /// then interface bound types will be visited by [TypeVisitor] provided by [Self::IBTV].
+    fn visit_interface_bound(&mut self, interface_bound_type: &mut ClassType) -> Self::IBTV;
+}
+
+#[cfg_attr(doc, aquamarine::aquamarine)]
+/// Visitor used for visiting [SignatureType].
 ///
 /// # Visit strategy
 /// ```mermaid
@@ -169,27 +420,27 @@ pub trait TypeVisitor {
     ///
     /// # Visit rule
     ///
-    /// Consider class path `example/Class.InnerClass[TT1;].InnerMostClass[TT2;]`, parameter `class_type` 
-    /// will be `example/Class`, the type arguments of the class type will be visited by 
-    /// [Self::visit_type_arguments] and [Self::visit_type_argument]. And inner classes will be visited 
+    /// Consider class path `example/Class.InnerClass[TT1;].InnerMostClass[TT2;]`, parameter `class_type`
+    /// will be `example/Class`, the type arguments of the class type will be visited by
+    /// [Self::visit_type_arguments] and [Self::visit_type_argument]. And inner classes will be visited
     /// by [Self::visit_inner_class_types] and [Self::visit_inner_class_type].
     fn visit_class_type(&mut self, class_type: &mut ClassType) {}
-    
+
     /// Visits type variable [TypeVariable](crate::asm::node::signature::TypeVariable).
-    /// 
+    ///
     /// # Visit rule
-    /// 
-    /// Consider type variable `TT;` parameter `name` will be `"T"`, since 
-    /// [TypeVariable](crate::asm::node::signature::TypeVariable) is guaranteed to be an terminal node 
+    ///
+    /// Consider type variable `TT;` parameter `name` will be `"T"`, since
+    /// [TypeVariable](crate::asm::node::signature::TypeVariable) is guaranteed to be an terminal node
     /// of the signature, no more visiting will be occurred on this type.
     fn visit_type_variable(&mut self, name: &mut String) {}
-    
+
     /// Visits inner classes of [ClassType].
     ///
     /// # Visit rule
     ///
     /// Consider class path `example/Class.InnerClass[TT1;].InnerMostClass[TT2;]`, parameter
-    /// `inner_classes` will be `[InnerClass[TT1;], InnerMostClass[TT2;]]`, and type arguments of both 
+    /// `inner_classes` will be `[InnerClass[TT1;], InnerMostClass[TT2;]]`, and type arguments of both
     /// inner classes will be visited by [Self::visit_type_arguments] in order.
     fn visit_inner_class_types(&mut self, inner_classes: &mut Vec<(String, Vec<TypeArgument>)>) {}
 
@@ -205,120 +456,44 @@ pub trait TypeVisitor {
     /// Visits all [TypeArgument] of [ClassType] or its inner class type.
     ///
     /// # Visit rule
-    /// 
+    ///
     /// Consider type argument signature `[TT1;TT2;]`, parameter `type_arguments` will be `[T1, T2]`,
     /// then each type arguments will be visited by [Self::visit_type_argument].
     fn visit_type_arguments(&mut self, type_arguments: &mut Vec<TypeArgument>) {}
 
     /// Visits [TypeArgument].
-    /// 
+    ///
     /// # Visit rule
-    /// 
+    ///
     /// Consider type argument `[+Ljava/lang/Object;]`, parameter `type_argument` will be `java/lang/Object`,
-    /// then the type argument will be visited by either [Self::visit_type_argument_bounded] or 
+    /// then the type argument will be visited by either [Self::visit_type_argument_bounded] or
     /// [Self::visit_type_argument_wildcard].
     fn visit_type_argument(&mut self, type_argument: &mut TypeArgument) {}
 
     /// Visits [TypeArgument::Bounded].
-    /// 
+    ///
     /// # Visit rule
-    /// 
-    /// Consider type argument `[+Ljava/lang/Object;]`, parameter `wildcard` will be 
+    ///
+    /// Consider type argument `[+Ljava/lang/Object;]`, parameter `wildcard` will be
     /// [WildcardIndicator::EXTENDS], and parameter `reference_type` will be `java/lang/Object`,
-    /// them the `reference_type` will be visited by either [Self::visit_array_type], 
+    /// them the `reference_type` will be visited by either [Self::visit_array_type],
     /// [Self::visit_class_type], or [Self::visit_type_variable].
-    fn visit_type_argument_bounded(&mut self, wildcard: &mut WildcardIndicator, reference_type: &mut ReferenceType) {}
+    fn visit_type_argument_bounded(
+        &mut self,
+        wildcard: &mut WildcardIndicator,
+        reference_type: &mut ReferenceType,
+    ) {
+    }
 
     /// Visits [TypeArgument::Wildcard].
-    /// 
+    ///
     /// # Visit rule
-    /// 
+    ///
     /// It is guaranteed that this function will only visit type argument `[*]`, as known as wildcard,
     /// and no more visiting will be occurred.
-    /// 
+    ///
     /// # Mutation
-    /// 
+    ///
     /// To mutate type argument itself, use [Self::visit_type_argument].
     fn visit_type_argument_wildcard(&mut self) {}
 }
-
-/// Default signature visitor implementation This visitor is meant to used in non-behavioral situations.
-/// 
-/// # Usage
-/// While implementing a signature visitor, you need to specify children visitor's implementation as
-/// well, sometimes you may not want to do anything with children visitor, to avoid this, you can use
-/// [SignatureVisitorImpl].
-/// 
-/// ```rust
-/// use ka_pi::asm::visitor::signature::SignatureVisitor;
-/// 
-/// #[derive(Default)]
-/// pub struct ExampleVisitor {
-///     // ...
-/// }
-/// ```
-#[derive(Debug, Default)]
-pub struct SignatureVisitorImpl {}
-
-impl SignatureVisitor for SignatureVisitorImpl {
-    type TV = Self;
-    type FTPV = Self;
-
-    fn visit_super_class(&mut self, super_class: &mut ClassType) -> Self::TV {
-        todo!()
-    }
-
-    fn visit_interfaces(&mut self, interfaces: &mut Vec<ClassType>) {
-        todo!()
-    }
-
-    fn visit_interface(&mut self, interface: &mut ClassType) -> Self::TV {
-        todo!()
-    }
-
-    fn visit_field_type(&mut self, field_type: &mut ReferenceType) -> Self::TV {
-        todo!()
-    }
-
-    fn visit_parameter_types(&mut self, parameter_types: &mut Vec<SignatureType>) {
-        todo!()
-    }
-
-    fn visit_parameter_type(&mut self, parameter_type: &mut SignatureType) -> Self::TV {
-        todo!()
-    }
-
-    fn visit_return_type(&mut self, return_type: &mut SignatureType) -> Self::TV {
-        todo!()
-    }
-
-    fn visit_exception_types(&mut self, throws_types: &mut Vec<ThrowsType>) {
-        todo!()
-    }
-
-    fn visit_exception_type(&mut self, throws_type: &mut ThrowsType) -> Self::TV {
-        todo!()
-    }
-
-    fn visit_formal_type_parameters(&mut self, formal_type_parameters: &mut Vec<FormalTypeParameter>) {
-        todo!()
-    }
-
-    fn visit_formal_type_parameter(&mut self, _: &mut FormalTypeParameter) -> Self::FTPV {
-        Self::default()
-    }
-}
-
-impl FormalTypeParameterVisitor for SignatureVisitorImpl {
-    type TV = Self;
-
-    fn visit_class_bound(&mut self) -> Self::TV {
-        Self::default()
-    }
-
-    fn visit_interface_bound(&mut self) -> Self::TV {
-        Self::default()
-    }
-}
-
-impl TypeVisitor for SignatureVisitorImpl {}

--- a/test/signature_parse.rs
+++ b/test/signature_parse.rs
@@ -1,7 +1,13 @@
 use insta::assert_yaml_snapshot;
 
+use ka_pi::asm::node::signature::{
+    ClassType, FormalTypeParameter, ReferenceType, SignatureType, ThrowsType,
+};
 use ka_pi::asm::parse::{parse_class_signature, parse_field_signature, parse_method_signature};
-use ka_pi::asm::visitor::signature::{FormalTypeParameterVisitor, SignatureVisitor, TypeVisitor};
+use ka_pi::asm::visitor::signature::{
+    ClassSignatureVisitor, FieldSignatureVisitor, FormalTypeParameterVisitable,
+    FormalTypeParameterVisitor, MethodSignatureVisitor, SignatureVisitor, TypeVisitor,
+};
 use ka_pi::asm::visitor::Visitable;
 use ka_pi::error::KapiResult;
 
@@ -50,53 +56,75 @@ fn test_method_signature_with_generic() -> KapiResult<()> {
 #[derive(Default)]
 struct Visitor {}
 
-impl SignatureVisitor for Visitor {
-    type TV = Self;
+impl SignatureVisitor for Visitor {}
+
+impl ClassSignatureVisitor for Visitor {
+    type SCTV = Self;
+    type ITV = Self;
+
+    fn visit_super_class(&mut self, _: &mut ClassType) -> Self::SCTV {
+        Self::default()
+    }
+
+    fn visit_interface(&mut self, _: &mut ClassType) -> Self::ITV {
+        Self::default()
+    }
+}
+
+impl FormalTypeParameterVisitable for Visitor {
     type FTPV = Self;
 
-    fn visit_super_class(&mut self) -> Self::TV {
-        Self::default()
-    }
+    fn visit_formal_type_parameter(
+        &mut self,
+        formal_type_parameter: &mut FormalTypeParameter,
+    ) -> Self::FTPV {
+        let FormalTypeParameter { parameter_name, .. } = formal_type_parameter;
 
-    fn visit_interface(&mut self) -> Self::TV {
-        Self::default()
-    }
-
-    fn visit_field_type(&mut self) -> Self::TV {
-        Self::default()
-    }
-
-    fn visit_parameter_type(&mut self) -> Self::TV {
-        Self::default()
-    }
-
-    fn visit_return_type(&mut self) -> Self::TV {
-        Self::default()
-    }
-
-    fn visit_exception_type(&mut self) -> Self::TV {
-        Self::default()
-    }
-
-    fn visit_formal_type_parameter(&mut self, name: &mut String) -> Self::FTPV {
-        if name == "T" {
-            *name = "V".to_string();
-        } else if name == "R" {
-            *name = "K".to_string();
+        if parameter_name == "T" {
+            *parameter_name = "V".to_string();
+        } else if parameter_name == "R" {
+            *parameter_name = "K".to_string();
         }
 
         Self::default()
     }
 }
 
-impl FormalTypeParameterVisitor for Visitor {
-    type TV = Self;
+impl FieldSignatureVisitor for Visitor {
+    type FTV = Self;
 
-    fn visit_class_bound(&mut self) -> Self::TV {
+    fn visit_field_type(&mut self, _: &mut ReferenceType) -> Self::FTV {
+        Self::default()
+    }
+}
+
+impl MethodSignatureVisitor for Visitor {
+    type PTV = Self;
+    type RTV = Self;
+    type ETV = Self;
+
+    fn visit_parameter_type(&mut self, _: &mut SignatureType) -> Self::PTV {
         Self::default()
     }
 
-    fn visit_interface_bound(&mut self) -> Self::TV {
+    fn visit_return_type(&mut self, _: &mut SignatureType) -> Self::RTV {
+        Self::default()
+    }
+
+    fn visit_exception_type(&mut self, _: &mut ThrowsType) -> Self::ETV {
+        Self::default()
+    }
+}
+
+impl FormalTypeParameterVisitor for Visitor {
+    type CBTV = Self;
+    type IBTV = Self;
+
+    fn visit_class_bound(&mut self, _: &mut ClassType) -> Self::CBTV {
+        Self::default()
+    }
+
+    fn visit_interface_bound(&mut self, _: &mut ClassType) -> Self::IBTV {
         Self::default()
     }
 }


### PR DESCRIPTION
```mermaid
flowchart
    subgraph SignatureVisitor
        SV_A0[(Entry Point)]
    end
    
    subgraph ClassSignatureVisitor
        CSV_A1{{FormalTypeParameterVisitable}}
        CSV_A3[visit_super_class]
        CSV_A4[visit_interfaces]
        CSV_A5[visit_interface]

        SV_A0 -->|Signature::Class| CSV_A1 --> CSV_A3 --> CSV_A4 --> CSV_A5
    end
    
    subgraph FieldSignatureVisitor
        FSV_A1[visit_field_type]

        SV_A0 -->|Signature::Field| FSV_A1
    end
    
    subgraph MethodVisitor
        MV_A1{{FormalTypeParameterVisitable}}
        MV_A3[visit_parameter_types]
        MV_A4[visit_parameter_type]
        MV_A5[visit_return_type]
        MV_A6[visit_exception_types]
        MV_A7[visit_exception_type]

        SV_A0 -->|Signature::Method| MV_A1 --> MV_A3 --> MV_A4 --> MV_A5 --> MV_A6 --> MV_A7
    end
    
    subgraph FormalTypeParameterVisitable
        FTPV0_A1[visit_formal_types]
        FTPV0_A2[visit_formal_type]

        CSV_A1 & MV_A1 --> FTPV0_A1
        FTPV0_A1 --> FTPV0_A2
    end
    
    subgraph FormalTypeParameterVisitor
        FTPV_A1[visit_class_bound]
        FTPV_A2[visit_interface_bounds]
        FTPV_A3[visit_interface_bound]

        FTPV0_A2 --> FTPV_A1
        FTPV_A1 --> FTPV_A2
        FTPV_A2 --> FTPV_A3
    end
    
    subgraph TypeVisitor
        TV_TYP_REF{ReferenceType}
        TV_TYP_SIG{SignatureType}
        TV_TYP_THR{ThrowsType}
        TV_TYP_BAS{BaseType}
        TV_TYP_ARR{ArrayType}
        TV_TYP_CLS{ClassType}
        TV_TYP_TYP_VAR{TypeVariable}
        
        TV_A1[visit_base_type]
        TV_A2[visit_class_type]
        TV_A3[visit_array_type]
        TV_A4[visit_type_variable]
        TV_B0[visit_type_arguments]
        TV_B1[visit_type_argument]
        TV_B2[visit_type_argument_bound]
        TV_B3[visit_type_argument_wildcard]
        TV_C0[visit_inner_classes]
        TV_C1[visit_inner_class]

        CSV_A3 & CSV_A5 & FTPV_A3 & FTPV_A1 & TV_TYP_REF & TV_B2 & TV_A3 --> TV_TYP_CLS

        FSV_A1 & TV_TYP_SIG & TV_TYP_THR --> TV_TYP_REF

        MV_A4 & MV_A5 --> TV_TYP_SIG
        MV_A7 --> TV_TYP_THR

        TV_TYP_SIG & TV_A3 --> TV_TYP_BAS
        TV_TYP_THR --> TV_TYP_TYP_VAR
        TV_TYP_REF --> TV_TYP_ARR
        TV_TYP_REF --> TV_TYP_TYP_VAR
        TV_TYP_BAS --> TV_A1
        TV_TYP_ARR --> TV_A3
        TV_TYP_CLS --> TV_A2
        TV_TYP_TYP_VAR --> TV_A4

        TV_A2 --> TV_B0
        TV_B0 --> TV_B1
        TV_B1 --> TV_B2
        TV_B1 --> TV_B3
        TV_B2 --> TV_A3 & TV_TYP_TYP_VAR

        TV_A2 --> TV_C0
        TV_C0 --> TV_C1
        TV_C1 --> TV_B0
        TV_C1 --> TV_C0
    end
```